### PR TITLE
feat: Planning Inbox Redesign - User-controlled triage flow

### DIFF
--- a/BRANCH-STATUS.md
+++ b/BRANCH-STATUS.md
@@ -28,7 +28,7 @@ Key changes:
 - [x] Conflict check completed (no overlapping work)
 - [x] Dependencies identified and noted
 - [x] Branch and worktree created
-- [ ] Implementation plan written (superpowers:writing-plans)
+- [x] Implementation plan written (superpowers:writing-plans)
 
 ### Dev
 - [ ] Tests written first (superpowers:test-driven-development)

--- a/BRANCH-STATUS.md
+++ b/BRANCH-STATUS.md
@@ -1,19 +1,23 @@
-# Branch Status: phase-7.5/feedback-pipeline
+# Branch Status: phase-7/planning-redesign
 
-**Created:** 2025-12-31
-**Design Doc:** docs/plans/2025-12-31-feedback-pipeline-implementation.md
-**Current Stage:** testing
-**Last Rebased:** 2025-12-31
+**Created:** 2026-01-02
+**Design Doc:** docs/plans/2026-01-02-planning-inbox-redesign.md
+**Current Stage:** planning
+**Last Rebased:** 2026-01-02
 
 ## Overview
 
-Feedback pipeline that captures `#selene-feedback` tagged notes, converts them to user stories via Ollama, and auto-generates a backlog file.
+Redesigns Phase 7 planning flow: ALL notes go through SeleneChat Inbox for user triage before any tasks are created. Removes auto-task creation. Adds Active/Parked project structure.
+
+Key changes:
+- No auto-routing to Things (user confirms everything)
+- Inbox triage with quick-action buttons
+- Active vs Parked projects to prevent overwhelm
+- Classification becomes UI hint, not routing decision
 
 ## Dependencies
 
-- Docker/n8n running
-- Ollama with mistral:7b
-- Workflow 01 (ingestion) active
+- None - this is a design revision that supersedes parts of Phase 7.1/7.2
 
 ---
 
@@ -21,68 +25,60 @@ Feedback pipeline that captures `#selene-feedback` tagged notes, converts them t
 
 ### Planning
 - [x] Design doc exists and approved
-- [x] Conflict check completed
-- [x] Dependencies identified
+- [x] Conflict check completed (no overlapping work)
+- [x] Dependencies identified and noted
 - [x] Branch and worktree created
-- [x] Implementation plan written
+- [ ] Implementation plan written (superpowers:writing-plans)
 
 ### Dev
-- [x] Task 1: Database migration (feedback_notes table)
-- [x] Task 2: Ingestion workflow modification (feedback detection)
-- [x] Task 3: Feedback processing workflow (09)
-- [x] Task 4: Backlog generator script
-- [x] Task 5: Automatic backlog generation in workflow
-- [x] Task 6: End-to-end test commit
+- [ ] Tests written first (superpowers:test-driven-development)
+- [ ] Core implementation complete
+- [ ] All tests passing
+- [ ] No linting/type errors
+- [ ] Code follows project patterns
 
 ### Testing
-- [x] Docker running and workflows active
-- [x] Test feedback ingestion with marker
-- [x] Test LLM processing
-- [x] Test backlog generation
-- [x] Cleanup test data
+- [ ] Unit tests pass
+- [ ] Integration tests pass (if applicable)
+- [ ] Manual testing completed
+- [ ] Edge cases verified
+- [ ] Verified with superpowers:verification-before-completion
 
 ### Docs
-- [x] Workflow 09 STATUS.md updated with test results
-- [x] Workflow 01 STATUS.md updated
-- [ ] ROADMAP.md updated
+- [x] Design documents updated
+- [ ] workflow STATUS.md updated (if workflow changed)
+- [ ] README updated (if interface changed)
+- [x] Roadmap docs updated
+- [ ] Code comments where needed
 
 ### Review
-- [x] Requested review (superpowers:requesting-code-review)
-- [x] Review feedback addressed
-- [x] Changes approved
+- [ ] Requested review (superpowers:requesting-code-review)
+- [ ] Review feedback addressed
+- [ ] Changes approved
 
 ### Ready
-- [x] Rebased on latest main
-- [x] Final test pass after rebase
-- [x] BRANCH-STATUS.md fully checked
-- [x] Ready for merge
-
----
-
-## Implementation Summary
-
-### Files Created
-- `database/migrations/009_add_feedback_notes.sql`
-- `workflows/09-feedback-processing/workflow.json`
-- `workflows/09-feedback-processing/README.md`
-- `workflows/09-feedback-processing/docs/STATUS.md`
-- `workflows/09-feedback-processing/scripts/test-with-markers.sh`
-- `prompts/feedback/user-story-conversion.md`
-- `scripts/generate-backlog.sh`
-
-### Files Modified
-- `database/schema.sql` (added feedback_notes)
-- `workflows/01-ingestion/workflow.json` (feedback detection + routing)
-- `workflows/01-ingestion/docs/STATUS.md`
-- `docs/backlog/user-stories.md` (auto-generated)
+- [ ] Rebased on latest main
+- [ ] Final test pass after rebase
+- [ ] BRANCH-STATUS.md fully checked
+- [ ] Ready for merge
 
 ---
 
 ## Notes
 
-**2025-12-31:** All 6 implementation tasks completed. Ready for testing stage.
+This redesign came from a brainstorming session (2026-01-02) discussing user stories and whether the auto-routing model made sense. Key insights:
 
-**2026-01-01:** Testing completed. PR created. Resolved merge conflict with main.
+1. User wants to verify AI understanding before tasks are created
+2. Automatic task creation could lead to Things inbox overwhelm
+3. The planning conversation itself is valuable, even for "simple" tasks
+4. Need Active/Parked distinction to prevent SeleneChat overwhelm
+5. Context memory needed for reopening old projects with new notes
+
+Future features identified:
+- Parking lot rot detection (surface stale items)
+- AI suggestions when Active doesn't appeal
+- Task check-in conversations ("why haven't you done this?")
+- Explicit "not this" correction for wrong project suggestions
 
 ---
 

--- a/BRANCH-STATUS.md
+++ b/BRANCH-STATUS.md
@@ -2,7 +2,7 @@
 
 **Created:** 2026-01-02
 **Design Doc:** docs/plans/2026-01-02-planning-inbox-redesign.md
-**Current Stage:** planning
+**Current Stage:** dev
 **Last Rebased:** 2026-01-02
 
 ## Overview
@@ -31,25 +31,25 @@ Key changes:
 - [x] Implementation plan written (superpowers:writing-plans)
 
 ### Dev
-- [ ] Tests written first (superpowers:test-driven-development)
-- [ ] Core implementation complete
-- [ ] All tests passing
-- [ ] No linting/type errors
-- [ ] Code follows project patterns
+- [x] Tests written first (superpowers:test-driven-development)
+- [x] Core implementation complete
+- [x] All tests passing
+- [x] No linting/type errors
+- [x] Code follows project patterns
 
 ### Testing
 - [ ] Unit tests pass
-- [ ] Integration tests pass (if applicable)
+- [x] Integration tests pass (if applicable)
 - [ ] Manual testing completed
 - [ ] Edge cases verified
 - [ ] Verified with superpowers:verification-before-completion
 
 ### Docs
 - [x] Design documents updated
-- [ ] workflow STATUS.md updated (if workflow changed)
+- [x] workflow STATUS.md updated (if workflow changed) - N/A, no workflow changes
 - [ ] README updated (if interface changed)
 - [x] Roadmap docs updated
-- [ ] Code comments where needed
+- [x] Code comments where needed
 
 ### Review
 - [ ] Requested review (superpowers:requesting-code-review)

--- a/SeleneChat/Sources/App/SeleneChatApp.swift
+++ b/SeleneChat/Sources/App/SeleneChatApp.swift
@@ -14,9 +14,21 @@ struct SeleneChatApp: App {
             NSApplication.shared.activate(ignoringOtherApps: true)
         }
 
+        // Configure services with database connection
+        configureServices()
+
         #if DEBUG
         setupDebugSystem()
         #endif
+    }
+
+    private func configureServices() {
+        // Configure InboxService and ProjectService with database connection
+        // These services need the db connection to query inbox notes and projects
+        if let db = DatabaseService.shared.db {
+            InboxService.shared.configure(with: db)
+            ProjectService.shared.configure(with: db)
+        }
     }
 
     #if DEBUG

--- a/SeleneChat/Sources/Models/InboxNote.swift
+++ b/SeleneChat/Sources/Models/InboxNote.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct InboxNote: Identifiable, Hashable, Codable {
+    let id: Int
+    let title: String
+    let content: String
+    let createdAt: Date
+
+    // Inbox-specific
+    var inboxStatus: InboxStatus
+    var suggestedType: NoteType?
+    var suggestedProjectId: Int?
+    var suggestedProjectName: String?
+
+    // From processed_notes
+    var concepts: [String]?
+    var primaryTheme: String?
+    var energyLevel: String?
+
+    enum InboxStatus: String, Codable {
+        case pending
+        case triaged
+        case archived
+    }
+
+    var preview: String {
+        String(content.prefix(150))
+    }
+
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: createdAt)
+    }
+}

--- a/SeleneChat/Sources/Models/NoteType.swift
+++ b/SeleneChat/Sources/Models/NoteType.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+enum NoteType: String, CaseIterable, Codable {
+    case quickTask = "quick_task"
+    case relatesToProject = "relates_to_project"
+    case newProject = "new_project"
+    case reflection = "reflection"
+
+    var displayName: String {
+        switch self {
+        case .quickTask: return "Quick task"
+        case .relatesToProject: return "Relates to project"
+        case .newProject: return "New project idea"
+        case .reflection: return "Reflection"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .quickTask: return "checklist"
+        case .relatesToProject: return "link"
+        case .newProject: return "plus.rectangle.on.folder"
+        case .reflection: return "bubble.left.and.text.bubble.right"
+        }
+    }
+
+    var emoji: String {
+        switch self {
+        case .quickTask: return "📋"
+        case .relatesToProject: return "🔗"
+        case .newProject: return "🆕"
+        case .reflection: return "💭"
+        }
+    }
+}

--- a/SeleneChat/Sources/Models/Project.swift
+++ b/SeleneChat/Sources/Models/Project.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct Project: Identifiable, Hashable, Codable {
+    let id: Int
+    var name: String
+    var status: Status
+    var primaryConcept: String?
+    var thingsProjectId: String?
+    let createdAt: Date
+    var lastActiveAt: Date?
+    var completedAt: Date?
+    var testRun: String?
+
+    // Computed from joins
+    var noteCount: Int = 0
+    var taskCount: Int = 0
+    var completedTaskCount: Int = 0
+
+    enum Status: String, CaseIterable, Codable {
+        case active
+        case parked
+        case completed
+
+        var icon: String {
+            switch self {
+            case .active: return "flame"
+            case .parked: return "parkingsign"
+            case .completed: return "checkmark.circle"
+            }
+        }
+
+        var color: String {
+            switch self {
+            case .active: return "orange"
+            case .parked: return "gray"
+            case .completed: return "green"
+            }
+        }
+    }
+
+    var timeSinceActive: String? {
+        guard let lastActive = lastActiveAt else { return nil }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: lastActive, relativeTo: Date())
+    }
+}

--- a/SeleneChat/Sources/Services/DatabaseService.swift
+++ b/SeleneChat/Sources/Services/DatabaseService.swift
@@ -12,7 +12,7 @@ class DatabaseService: ObservableObject {
         }
     }
 
-    private var db: Connection?
+    private(set) var db: Connection?
 
     // Table references
     private let rawNotes = Table("raw_notes")

--- a/SeleneChat/Sources/Services/DatabaseService.swift
+++ b/SeleneChat/Sources/Services/DatabaseService.swift
@@ -96,6 +96,7 @@ class DatabaseService: ObservableObject {
             // Run migrations
             try? createChatSessionsTable()
             try? Migration001_TaskLinks.run(db: db!)
+            try? Migration002_PlanningInbox.run(db: db!)
         } catch {
             isConnected = false
             #if DEBUG

--- a/SeleneChat/Sources/Services/InboxService.swift
+++ b/SeleneChat/Sources/Services/InboxService.swift
@@ -1,0 +1,140 @@
+// InboxService.swift
+// SeleneChat
+//
+// Created for Phase 7: Planning Inbox Redesign
+// Manages inbox triage workflow for pending notes
+
+import Foundation
+import SQLite
+
+class InboxService: ObservableObject {
+    static let shared = InboxService()
+
+    private var db: Connection?
+
+    // Table references
+    private let rawNotes = Table("raw_notes")
+    private let processedNotes = Table("processed_notes")
+    private let projects = Table("projects")
+
+    // raw_notes columns
+    private let noteId = Expression<Int64>("id")
+    private let noteTitle = Expression<String>("title")
+    private let noteContent = Expression<String>("content")
+    private let noteCreatedAt = Expression<String>("created_at")
+    private let inboxStatus = Expression<String?>("inbox_status")
+    private let suggestedType = Expression<String?>("suggested_type")
+    private let suggestedProjectId = Expression<Int64?>("suggested_project_id")
+    private let testRun = Expression<String?>("test_run")
+
+    // processed_notes columns
+    private let rawNoteId = Expression<Int64>("raw_note_id")
+    private let concepts = Expression<String?>("concepts")
+    private let primaryTheme = Expression<String?>("primary_theme")
+    private let energyLevel = Expression<String?>("energy_level")
+
+    // projects columns
+    private let projectId = Expression<Int64>("id")
+    private let projectName = Expression<String>("name")
+
+    init() {}
+
+    func configure(with db: Connection) {
+        self.db = db
+    }
+
+    // MARK: - Fetch Pending Notes
+
+    func getPendingNotes() async throws -> [InboxNote] {
+        guard let db = db else {
+            throw DatabaseService.DatabaseError.notConnected
+        }
+
+        let query = rawNotes
+            .join(.leftOuter, processedNotes, on: rawNotes[noteId] == processedNotes[rawNoteId])
+            .join(.leftOuter, projects, on: rawNotes[suggestedProjectId] == projects[projectId])
+            .filter(rawNotes[inboxStatus] == "pending" || rawNotes[inboxStatus] == nil)
+            .filter(rawNotes[testRun] == nil)
+            .order(rawNotes[noteCreatedAt].desc)
+            .limit(50)
+
+        var notes: [InboxNote] = []
+
+        for row in try db.prepare(query) {
+            let note = try parseInboxNote(from: row)
+            notes.append(note)
+        }
+
+        return notes
+    }
+
+    private func parseInboxNote(from row: Row) throws -> InboxNote {
+        let dateFormatter = ISO8601DateFormatter()
+
+        // Parse concepts JSON
+        var conceptsArray: [String]? = nil
+        if let conceptsStr = try? row.get(processedNotes[concepts]),
+           let data = conceptsStr.data(using: .utf8) {
+            conceptsArray = try? JSONDecoder().decode([String].self, from: data)
+        }
+
+        // Parse suggested type
+        var noteType: NoteType? = nil
+        if let typeStr = try? row.get(rawNotes[suggestedType]) {
+            noteType = NoteType(rawValue: typeStr)
+        }
+
+        return InboxNote(
+            id: Int(try row.get(rawNotes[noteId])),
+            title: try row.get(rawNotes[noteTitle]),
+            content: try row.get(rawNotes[noteContent]),
+            createdAt: dateFormatter.date(from: try row.get(rawNotes[noteCreatedAt])) ?? Date(),
+            inboxStatus: .pending,
+            suggestedType: noteType,
+            suggestedProjectId: (try? row.get(rawNotes[suggestedProjectId])).map { Int($0) },
+            suggestedProjectName: try? row.get(projects[projectName]),
+            concepts: conceptsArray,
+            primaryTheme: try? row.get(processedNotes[primaryTheme]),
+            energyLevel: try? row.get(processedNotes[energyLevel])
+        )
+    }
+
+    // MARK: - Triage Actions
+
+    func markTriaged(noteId: Int) async throws {
+        guard let db = db else {
+            throw DatabaseService.DatabaseError.notConnected
+        }
+
+        let note = rawNotes.filter(self.noteId == Int64(noteId))
+        try db.run(note.update(inboxStatus <- "triaged"))
+    }
+
+    func markArchived(noteId: Int) async throws {
+        guard let db = db else {
+            throw DatabaseService.DatabaseError.notConnected
+        }
+
+        let note = rawNotes.filter(self.noteId == Int64(noteId))
+        try db.run(note.update(inboxStatus <- "archived"))
+    }
+
+    func attachToProject(noteId: Int, projectId: Int) async throws {
+        guard let db = db else {
+            throw DatabaseService.DatabaseError.notConnected
+        }
+
+        // Insert into project_notes
+        let projectNotes = Table("project_notes")
+        let projectIdCol = Expression<Int64>("project_id")
+        let rawNoteIdCol = Expression<Int64>("raw_note_id")
+
+        try db.run(projectNotes.insert(or: .ignore,
+            projectIdCol <- Int64(projectId),
+            rawNoteIdCol <- Int64(noteId)
+        ))
+
+        // Mark note as triaged
+        try await markTriaged(noteId: noteId)
+    }
+}

--- a/SeleneChat/Sources/Services/Migrations/Migration002_PlanningInbox.swift
+++ b/SeleneChat/Sources/Services/Migrations/Migration002_PlanningInbox.swift
@@ -1,0 +1,69 @@
+// Migration002_PlanningInbox.swift
+// SeleneChat
+//
+// Created for Phase 7: Planning Inbox Redesign
+// Creates projects table and adds inbox columns to raw_notes
+
+import Foundation
+import SQLite
+
+struct Migration002_PlanningInbox {
+    static func run(db: Connection) throws {
+        // Create projects table
+        try db.run("""
+            CREATE TABLE IF NOT EXISTS projects (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                status TEXT DEFAULT 'parked'
+                    CHECK(status IN ('active', 'parked', 'completed')),
+                primary_concept TEXT,
+                things_project_id TEXT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                last_active_at DATETIME,
+                completed_at DATETIME,
+                test_run TEXT DEFAULT NULL
+            )
+        """)
+
+        try db.run("CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status)")
+        try db.run("CREATE INDEX IF NOT EXISTS idx_projects_test_run ON projects(test_run)")
+
+        // Create project_notes junction table
+        try db.run("""
+            CREATE TABLE IF NOT EXISTS project_notes (
+                project_id INTEGER NOT NULL,
+                raw_note_id INTEGER NOT NULL,
+                attached_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (project_id, raw_note_id),
+                FOREIGN KEY (project_id) REFERENCES projects(id),
+                FOREIGN KEY (raw_note_id) REFERENCES raw_notes(id)
+            )
+        """)
+
+        try db.run("CREATE INDEX IF NOT EXISTS idx_project_notes_project ON project_notes(project_id)")
+        try db.run("CREATE INDEX IF NOT EXISTS idx_project_notes_note ON project_notes(raw_note_id)")
+
+        // Add inbox columns to raw_notes (ignore if already exist)
+        do {
+            try db.run("ALTER TABLE raw_notes ADD COLUMN inbox_status TEXT DEFAULT 'pending'")
+        } catch {
+            // Column may already exist
+        }
+
+        do {
+            try db.run("ALTER TABLE raw_notes ADD COLUMN suggested_type TEXT")
+        } catch {
+            // Column may already exist
+        }
+
+        do {
+            try db.run("ALTER TABLE raw_notes ADD COLUMN suggested_project_id INTEGER")
+        } catch {
+            // Column may already exist
+        }
+
+        try db.run("CREATE INDEX IF NOT EXISTS idx_raw_notes_inbox_status ON raw_notes(inbox_status)")
+
+        print("Migration 002: Planning inbox tables created")
+    }
+}

--- a/SeleneChat/Sources/Services/ProjectService.swift
+++ b/SeleneChat/Sources/Services/ProjectService.swift
@@ -1,0 +1,214 @@
+// ProjectService.swift
+// SeleneChat
+//
+// Created for Phase 7: Planning Inbox Redesign
+// Manages Active/Parked project structure with ADHD-optimized limits
+
+import Foundation
+import SQLite
+
+class ProjectService: ObservableObject {
+    static let shared = ProjectService()
+
+    private var db: Connection?
+
+    // Table references
+    private let projects = Table("projects")
+    private let projectNotes = Table("project_notes")
+
+    // projects columns
+    private let projectId = Expression<Int64>("id")
+    private let projectName = Expression<String>("name")
+    private let projectStatus = Expression<String>("status")
+    private let primaryConcept = Expression<String?>("primary_concept")
+    private let thingsProjectId = Expression<String?>("things_project_id")
+    private let createdAt = Expression<String>("created_at")
+    private let lastActiveAt = Expression<String?>("last_active_at")
+    private let completedAt = Expression<String?>("completed_at")
+    private let testRun = Expression<String?>("test_run")
+
+    // project_notes columns
+    private let pnProjectId = Expression<Int64>("project_id")
+    private let pnRawNoteId = Expression<Int64>("raw_note_id")
+
+    // ADHD-optimized limit: prevents overwhelm from too many active projects
+    private let maxActiveProjects = 5
+
+    init() {}
+
+    func configure(with db: Connection) {
+        self.db = db
+    }
+
+    // MARK: - Fetch Projects
+
+    func getActiveProjects() async throws -> [Project] {
+        guard let db = db else {
+            throw DatabaseService.DatabaseError.notConnected
+        }
+
+        let query = projects
+            .filter(projectStatus == "active")
+            .filter(testRun == nil)
+            .order(lastActiveAt.desc)
+
+        var projectList: [Project] = []
+
+        for row in try db.prepare(query) {
+            var project = try parseProject(from: row)
+            project.noteCount = try await getNoteCount(for: project.id)
+            projectList.append(project)
+        }
+
+        return projectList
+    }
+
+    func getParkedProjects() async throws -> [Project] {
+        guard let db = db else {
+            throw DatabaseService.DatabaseError.notConnected
+        }
+
+        let query = projects
+            .filter(projectStatus == "parked")
+            .filter(testRun == nil)
+            .order(lastActiveAt.desc)
+
+        var projectList: [Project] = []
+
+        for row in try db.prepare(query) {
+            var project = try parseProject(from: row)
+            project.noteCount = try await getNoteCount(for: project.id)
+            projectList.append(project)
+        }
+
+        return projectList
+    }
+
+    private func getNoteCount(for projectIdValue: Int) async throws -> Int {
+        guard let db = db else { return 0 }
+
+        let count = try db.scalar(
+            projectNotes.filter(pnProjectId == Int64(projectIdValue)).count
+        )
+        return count
+    }
+
+    private func parseProject(from row: Row) throws -> Project {
+        let dateFormatter = ISO8601DateFormatter()
+
+        return Project(
+            id: Int(try row.get(projectId)),
+            name: try row.get(projectName),
+            status: Project.Status(rawValue: try row.get(projectStatus)) ?? .parked,
+            primaryConcept: try? row.get(primaryConcept),
+            thingsProjectId: try? row.get(thingsProjectId),
+            createdAt: dateFormatter.date(from: try row.get(createdAt)) ?? Date(),
+            lastActiveAt: (try? row.get(lastActiveAt)).flatMap { dateFormatter.date(from: $0) },
+            completedAt: (try? row.get(completedAt)).flatMap { dateFormatter.date(from: $0) },
+            testRun: try? row.get(testRun)
+        )
+    }
+
+    // MARK: - Create Project
+
+    func createProject(name: String, fromNoteId: Int? = nil, concept: String? = nil) async throws -> Project {
+        guard let db = db else {
+            throw DatabaseService.DatabaseError.notConnected
+        }
+
+        let dateFormatter = ISO8601DateFormatter()
+        let now = dateFormatter.string(from: Date())
+
+        let id = try db.run(projects.insert(
+            projectName <- name,
+            projectStatus <- "parked",
+            primaryConcept <- concept,
+            createdAt <- now,
+            lastActiveAt <- now
+        ))
+
+        // If created from a note, attach it
+        if let noteId = fromNoteId {
+            try db.run(projectNotes.insert(
+                pnProjectId <- id,
+                pnRawNoteId <- Int64(noteId)
+            ))
+        }
+
+        return Project(
+            id: Int(id),
+            name: name,
+            status: .parked,
+            primaryConcept: concept,
+            thingsProjectId: nil,
+            createdAt: Date(),
+            lastActiveAt: Date(),
+            completedAt: nil,
+            testRun: nil,
+            noteCount: fromNoteId != nil ? 1 : 0
+        )
+    }
+
+    // MARK: - Status Management
+
+    func activateProject(_ projectIdValue: Int) async throws {
+        guard let db = db else {
+            throw DatabaseService.DatabaseError.notConnected
+        }
+
+        // Check active count before allowing activation
+        let activeCount = try db.scalar(
+            projects.filter(projectStatus == "active").filter(testRun == nil).count
+        )
+
+        if activeCount >= maxActiveProjects {
+            throw ProjectError.tooManyActive
+        }
+
+        let dateFormatter = ISO8601DateFormatter()
+        let now = dateFormatter.string(from: Date())
+
+        let project = projects.filter(projectId == Int64(projectIdValue))
+        try db.run(project.update(
+            projectStatus <- "active",
+            lastActiveAt <- now
+        ))
+    }
+
+    func parkProject(_ projectIdValue: Int) async throws {
+        guard let db = db else {
+            throw DatabaseService.DatabaseError.notConnected
+        }
+
+        let project = projects.filter(projectId == Int64(projectIdValue))
+        try db.run(project.update(projectStatus <- "parked"))
+    }
+
+    func completeProject(_ projectIdValue: Int) async throws {
+        guard let db = db else {
+            throw DatabaseService.DatabaseError.notConnected
+        }
+
+        let dateFormatter = ISO8601DateFormatter()
+        let now = dateFormatter.string(from: Date())
+
+        let project = projects.filter(projectId == Int64(projectIdValue))
+        try db.run(project.update(
+            projectStatus <- "completed",
+            completedAt <- now
+        ))
+    }
+
+    // MARK: - Error Types
+
+    enum ProjectError: Error, LocalizedError {
+        case tooManyActive
+
+        var errorDescription: String? {
+            switch self {
+            case .tooManyActive:
+                return "Maximum 5 active projects. Park one first."
+            }
+        }
+    }
+}

--- a/SeleneChat/Sources/Views/Planning/ActiveProjectsList.swift
+++ b/SeleneChat/Sources/Views/Planning/ActiveProjectsList.swift
@@ -1,0 +1,117 @@
+// SeleneChat/Sources/Views/Planning/ActiveProjectsList.swift
+import SwiftUI
+
+struct ActiveProjectsList: View {
+    @StateObject private var projectService = ProjectService.shared
+
+    @State private var projects: [Project] = []
+    @State private var isLoading = true
+    @State private var error: String?
+
+    let onSelectProject: (Project) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Section header
+            HStack {
+                Image(systemName: "flame")
+                    .foregroundColor(.orange)
+                Text("Active")
+                    .font(.headline)
+
+                if !projects.isEmpty {
+                    Text("(\(projects.count))")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            // Content
+            if isLoading {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                .padding()
+            } else if projects.isEmpty {
+                emptyState
+            } else {
+                LazyVStack(spacing: 8) {
+                    ForEach(projects) { project in
+                        ProjectRowView(project: project)
+                            .onTapGesture { onSelectProject(project) }
+                    }
+                }
+                .padding()
+            }
+        }
+        .task {
+            await loadProjects()
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Text("No active projects")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Text("Start from inbox or activate a parked project")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+    }
+
+    private func loadProjects() async {
+        isLoading = true
+
+        do {
+            projects = try await projectService.getActiveProjects()
+        } catch {
+            self.error = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+}
+
+struct ProjectRowView: View {
+    let project: Project
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(project.name)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                HStack(spacing: 8) {
+                    Label("\(project.noteCount)", systemImage: "doc")
+                    if let time = project.timeSinceActive {
+                        Text(time)
+                    }
+                }
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(12)
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(8)
+        .contentShape(Rectangle())
+    }
+}

--- a/SeleneChat/Sources/Views/Planning/InboxView.swift
+++ b/SeleneChat/Sources/Views/Planning/InboxView.swift
@@ -1,0 +1,183 @@
+// SeleneChat/Sources/Views/Planning/InboxView.swift
+import SwiftUI
+
+struct InboxView: View {
+    @EnvironmentObject var databaseService: DatabaseService
+    @StateObject private var inboxService = InboxService.shared
+    @StateObject private var projectService = ProjectService.shared
+
+    @State private var notes: [InboxNote] = []
+    @State private var isLoading = true
+    @State private var error: String?
+
+    @State private var selectedNoteForTask: InboxNote?
+    @State private var showTaskConfirmation = false
+
+    private let thingsService = ThingsURLService.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Section header
+            HStack {
+                Image(systemName: "tray.and.arrow.down")
+                Text("Inbox")
+                    .font(.headline)
+
+                if !notes.isEmpty {
+                    Text("(\(notes.count))")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                Button(action: { Task { await loadNotes() } }) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.caption)
+                }
+                .buttonStyle(.plain)
+                .disabled(isLoading)
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            // Content
+            if isLoading {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                .padding()
+            } else if notes.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(notes) { note in
+                            TriageCardView(
+                                note: note,
+                                onCreateTask: { startTaskCreation(for: note) },
+                                onAddToProject: { addToProject(note) },
+                                onStartProject: { startProject(from: note) },
+                                onPark: { parkNote(note) },
+                                onArchive: { archiveNote(note) }
+                            )
+                        }
+                    }
+                    .padding()
+                }
+            }
+        }
+        .task {
+            await loadNotes()
+        }
+        .sheet(isPresented: $showTaskConfirmation) {
+            if let note = selectedNoteForTask {
+                QuickTaskConfirmation(
+                    note: note,
+                    onConfirm: { taskText in
+                        Task { await createTask(taskText, from: note) }
+                    },
+                    onCancel: { showTaskConfirmation = false }
+                )
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.circle")
+                .font(.system(size: 40))
+                .foregroundColor(.green)
+            Text("Inbox clear!")
+                .font(.headline)
+            Text("New notes will appear here for triage")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+    }
+
+    private func loadNotes() async {
+        isLoading = true
+        error = nil
+
+        do {
+            notes = try await inboxService.getPendingNotes()
+        } catch {
+            self.error = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    private func startTaskCreation(for note: InboxNote) {
+        selectedNoteForTask = note
+        showTaskConfirmation = true
+    }
+
+    private func createTask(_ taskText: String, from note: InboxNote) async {
+        do {
+            try await thingsService.createTask(
+                title: taskText,
+                notes: nil,
+                tags: [],
+                energy: note.energyLevel,
+                sourceNoteId: note.id,
+                threadId: nil
+            )
+            try await inboxService.markTriaged(noteId: note.id)
+            await loadNotes()
+        } catch {
+            self.error = error.localizedDescription
+        }
+
+        showTaskConfirmation = false
+        selectedNoteForTask = nil
+    }
+
+    private func addToProject(_ note: InboxNote) {
+        // TODO: Show project picker
+        // For now, if suggested project exists, use that
+        if let projectId = note.suggestedProjectId {
+            Task {
+                try? await inboxService.attachToProject(noteId: note.id, projectId: projectId)
+                await loadNotes()
+            }
+        }
+    }
+
+    private func startProject(from note: InboxNote) {
+        Task {
+            do {
+                let _ = try await projectService.createProject(
+                    name: note.title,
+                    fromNoteId: note.id,
+                    concept: note.concepts?.first
+                )
+                try await inboxService.markTriaged(noteId: note.id)
+                await loadNotes()
+            } catch {
+                self.error = error.localizedDescription
+            }
+        }
+    }
+
+    private func parkNote(_ note: InboxNote) {
+        Task {
+            try? await inboxService.markTriaged(noteId: note.id)
+            await loadNotes()
+        }
+    }
+
+    private func archiveNote(_ note: InboxNote) {
+        Task {
+            try? await inboxService.markArchived(noteId: note.id)
+            await loadNotes()
+        }
+    }
+}

--- a/SeleneChat/Sources/Views/Planning/ParkedProjectsList.swift
+++ b/SeleneChat/Sources/Views/Planning/ParkedProjectsList.swift
@@ -1,0 +1,132 @@
+// SeleneChat/Sources/Views/Planning/ParkedProjectsList.swift
+import SwiftUI
+
+struct ParkedProjectsList: View {
+    @StateObject private var projectService = ProjectService.shared
+
+    @State private var projects: [Project] = []
+    @State private var isLoading = true
+    @State private var isExpanded = false
+    @State private var error: String?
+
+    let onSelectProject: (Project) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Section header (always visible)
+            Button(action: { withAnimation { isExpanded.toggle() } }) {
+                HStack {
+                    Image(systemName: "parkingsign")
+                        .foregroundColor(.gray)
+                    Text("Parked")
+                        .font(.headline)
+
+                    if !projects.isEmpty {
+                        Text("(\(projects.count))")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+
+                    Spacer()
+
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            if isExpanded {
+                Divider()
+
+                // Content
+                if isLoading {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }
+                    .padding()
+                } else if projects.isEmpty {
+                    Text("No parked projects")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                } else {
+                    LazyVStack(spacing: 8) {
+                        ForEach(projects) { project in
+                            ParkedProjectRow(
+                                project: project,
+                                onActivate: { activateProject(project) },
+                                onSelect: { onSelectProject(project) }
+                            )
+                        }
+                    }
+                    .padding()
+                }
+            }
+        }
+        .task {
+            await loadProjects()
+        }
+    }
+
+    private func loadProjects() async {
+        isLoading = true
+
+        do {
+            projects = try await projectService.getParkedProjects()
+        } catch {
+            self.error = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    private func activateProject(_ project: Project) {
+        Task {
+            do {
+                try await projectService.activateProject(project.id)
+                await loadProjects()
+            } catch {
+                self.error = error.localizedDescription
+            }
+        }
+    }
+}
+
+struct ParkedProjectRow: View {
+    let project: Project
+    let onActivate: () -> Void
+    let onSelect: () -> Void
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(project.name)
+                    .font(.caption)
+
+                if let time = project.timeSinceActive {
+                    Text("Last active \(time)")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .onTapGesture { onSelect() }
+
+            Spacer()
+
+            Button("Activate") {
+                onActivate()
+            }
+            .font(.caption)
+            .buttonStyle(.bordered)
+        }
+        .padding(8)
+        .background(Color(NSColor.controlBackgroundColor).opacity(0.5))
+        .cornerRadius(6)
+    }
+}

--- a/SeleneChat/Sources/Views/Planning/QuickTaskConfirmation.swift
+++ b/SeleneChat/Sources/Views/Planning/QuickTaskConfirmation.swift
@@ -1,0 +1,81 @@
+// SeleneChat/Sources/Views/Planning/QuickTaskConfirmation.swift
+import SwiftUI
+
+struct QuickTaskConfirmation: View {
+    let note: InboxNote
+    let onConfirm: (String) -> Void
+    let onCancel: () -> Void
+
+    @State private var taskText: String
+    @State private var isSubmitting = false
+
+    init(note: InboxNote, onConfirm: @escaping (String) -> Void, onCancel: @escaping () -> Void) {
+        self.note = note
+        self.onConfirm = onConfirm
+        self.onCancel = onCancel
+        // Initialize with note title as default task text
+        _taskText = State(initialValue: note.title)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Header
+            HStack {
+                Text("📋")
+                Text("Quick task")
+                    .font(.headline)
+                Spacer()
+                Button(action: onCancel) {
+                    Image(systemName: "xmark")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Divider()
+
+            // Original note
+            VStack(alignment: .leading, spacing: 4) {
+                Text("From note:")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Text(note.preview)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+            }
+
+            // Editable task text
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Task to create:")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                TextField("Task text", text: $taskText, axis: .vertical)
+                    .textFieldStyle(.roundedBorder)
+                    .lineLimit(1...3)
+            }
+
+            Divider()
+
+            // Actions
+            HStack {
+                Spacer()
+
+                Button("Cancel") {
+                    onCancel()
+                }
+                .keyboardShortcut(.escape)
+
+                Button("Send to Things") {
+                    isSubmitting = true
+                    onConfirm(taskText)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(taskText.isEmpty || isSubmitting)
+                .keyboardShortcut(.return)
+            }
+        }
+        .padding()
+        .frame(width: 400)
+    }
+}

--- a/SeleneChat/Sources/Views/Planning/TriageCardView.swift
+++ b/SeleneChat/Sources/Views/Planning/TriageCardView.swift
@@ -1,0 +1,92 @@
+// SeleneChat/Sources/Views/Planning/TriageCardView.swift
+import SwiftUI
+
+struct TriageCardView: View {
+    let note: InboxNote
+    let onCreateTask: () -> Void
+    let onAddToProject: () -> Void
+    let onStartProject: () -> Void
+    let onPark: () -> Void
+    let onArchive: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Type badge and date
+            HStack {
+                typeBadge
+                Spacer()
+                Text(note.formattedDate)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            // Note content
+            Text(note.title)
+                .font(.headline)
+                .lineLimit(1)
+
+            Text(note.preview)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+
+            // Suggested project (if relates_to_project)
+            if let projectName = note.suggestedProjectName {
+                HStack(spacing: 4) {
+                    Image(systemName: "link")
+                        .font(.caption)
+                    Text(projectName)
+                        .font(.caption)
+                        .foregroundColor(.accentColor)
+                }
+            }
+
+            // Action buttons
+            actionButtons
+        }
+        .padding()
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(12)
+    }
+
+    @ViewBuilder
+    private var typeBadge: some View {
+        if let type = note.suggestedType {
+            HStack(spacing: 4) {
+                Text(type.emoji)
+                Text(type.displayName)
+            }
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.accentColor.opacity(0.1))
+            .cornerRadius(6)
+        }
+    }
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        HStack(spacing: 8) {
+            // Primary actions based on type
+            if note.suggestedType == .quickTask {
+                Button("Create Task") { onCreateTask() }
+                    .buttonStyle(.borderedProminent)
+            } else if note.suggestedType == .relatesToProject {
+                Button("Add to Project") { onAddToProject() }
+                    .buttonStyle(.borderedProminent)
+            } else {
+                Button("Start Project") { onStartProject() }
+                    .buttonStyle(.borderedProminent)
+            }
+
+            Button("Park") { onPark() }
+                .buttonStyle(.bordered)
+
+            Button(action: onArchive) {
+                Image(systemName: "archivebox")
+            }
+            .buttonStyle(.bordered)
+        }
+        .font(.caption)
+    }
+}

--- a/SeleneChat/Sources/Views/ProjectDetailView.swift
+++ b/SeleneChat/Sources/Views/ProjectDetailView.swift
@@ -1,0 +1,121 @@
+// ProjectDetailView.swift
+// SeleneChat
+//
+// Created for Phase 7: Planning Inbox Redesign
+// Placeholder for project detail view - will be implemented in future task
+
+import SwiftUI
+
+struct ProjectDetailView: View {
+    let project: Project
+    let onBack: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Button(action: onBack) {
+                    Label("Back", systemImage: "chevron.left")
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
+
+                // Status badge
+                HStack(spacing: 4) {
+                    Image(systemName: project.status.icon)
+                    Text(project.status.rawValue.capitalized)
+                }
+                .font(.caption)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(statusColor.opacity(0.1))
+                .foregroundColor(statusColor)
+                .cornerRadius(6)
+
+                Spacer()
+
+                // Placeholder for future actions
+                Menu {
+                    Button("Park Project", systemImage: "parkingsign") {}
+                    Button("Complete Project", systemImage: "checkmark.circle") {}
+                    Divider()
+                    Button("Delete Project", systemImage: "trash", role: .destructive) {}
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+                .buttonStyle(.plain)
+            }
+            .padding()
+
+            Divider()
+
+            // Project info
+            VStack(alignment: .leading, spacing: 16) {
+                // Title
+                Text(project.name)
+                    .font(.title2)
+                    .fontWeight(.semibold)
+
+                // Metadata
+                HStack(spacing: 16) {
+                    if let concept = project.primaryConcept {
+                        Label(concept, systemImage: "tag")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+
+                    Label("\(project.noteCount) notes", systemImage: "doc")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    if let timeSince = project.timeSinceActive {
+                        Label(timeSince, systemImage: "clock")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.accentColor.opacity(0.05))
+
+            Divider()
+
+            // Placeholder content
+            Spacer()
+
+            VStack(spacing: 12) {
+                Image(systemName: "hammer.fill")
+                    .font(.system(size: 48))
+                    .foregroundColor(.secondary.opacity(0.5))
+
+                Text("Project detail view coming soon")
+                    .font(.headline)
+                    .foregroundColor(.secondary)
+
+                Text("This will show project notes, tasks, and planning threads.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding()
+
+            Spacer()
+        }
+        .onAppear {
+            #if DEBUG
+            DebugLogger.shared.log(.nav, "Appeared: ProjectDetailView - \(project.name)")
+            ActionTracker.shared.track(action: "viewAppeared", params: ["view": "ProjectDetailView", "projectId": "\(project.id)"])
+            #endif
+        }
+    }
+
+    private var statusColor: Color {
+        switch project.status {
+        case .active: return .orange
+        case .parked: return .gray
+        case .completed: return .green
+        }
+    }
+}

--- a/database/migrations/011_planning_inbox.sql
+++ b/database/migrations/011_planning_inbox.sql
@@ -1,0 +1,53 @@
+-- 011_planning_inbox.sql
+-- Phase 7: Planning Inbox Redesign
+-- Creates projects table, project_notes junction, and modifies raw_notes
+
+BEGIN TRANSACTION;
+
+-- Projects table for Active/Parked structure
+CREATE TABLE IF NOT EXISTS projects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    status TEXT DEFAULT 'parked'
+        CHECK(status IN ('active', 'parked', 'completed')),
+    primary_concept TEXT,
+    things_project_id TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_active_at DATETIME,
+    completed_at DATETIME,
+    test_run TEXT DEFAULT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);
+CREATE INDEX IF NOT EXISTS idx_projects_test_run ON projects(test_run);
+
+-- Junction table linking projects to notes
+CREATE TABLE IF NOT EXISTS project_notes (
+    project_id INTEGER NOT NULL,
+    raw_note_id INTEGER NOT NULL,
+    attached_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (project_id, raw_note_id),
+    FOREIGN KEY (project_id) REFERENCES projects(id),
+    FOREIGN KEY (raw_note_id) REFERENCES raw_notes(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_notes_project ON project_notes(project_id);
+CREATE INDEX IF NOT EXISTS idx_project_notes_note ON project_notes(raw_note_id);
+
+-- Add inbox tracking columns to raw_notes
+-- inbox_status: pending (new), triaged (processed), archived (hidden)
+-- suggested_type: AI hint for triage (quick_task, relates_to_project, new_project, reflection)
+-- suggested_project_id: If relates_to_project, which project
+
+ALTER TABLE raw_notes ADD COLUMN inbox_status TEXT DEFAULT 'pending'
+    CHECK(inbox_status IN ('pending', 'triaged', 'archived'));
+
+ALTER TABLE raw_notes ADD COLUMN suggested_type TEXT
+    CHECK(suggested_type IN ('quick_task', 'relates_to_project', 'new_project', 'reflection'));
+
+ALTER TABLE raw_notes ADD COLUMN suggested_project_id INTEGER
+    REFERENCES projects(id);
+
+CREATE INDEX IF NOT EXISTS idx_raw_notes_inbox_status ON raw_notes(inbox_status);
+
+COMMIT;

--- a/docs/plans/2025-12-30-task-extraction-planning-design.md
+++ b/docs/plans/2025-12-30-task-extraction-planning-design.md
@@ -1,9 +1,26 @@
 # Task Extraction and Planning Architecture Design
 
 **Created:** 2025-12-30
-**Status:** Approved
+**Status:** Partially Superseded (routing logic revised)
+**Revised:** 2026-01-02
 **Phase:** 7.1 Revision - Supersedes previous task extraction design
 **Context:** Brainstorming session on project identification, planning, and task extraction
+
+---
+
+> **⚠️ ROUTING LOGIC REVISED (2026-01-02)**
+>
+> The **auto-routing** behavior described in this document has been changed:
+> - **Before:** `actionable` notes auto-created tasks in Things
+> - **After:** ALL notes park in SeleneChat Inbox for user triage
+>
+> **See:** `docs/plans/2026-01-02-planning-inbox-redesign.md` for the current routing design.
+>
+> The sections below remain useful for:
+> - Metadata extraction (still applies)
+> - Classification logic (now used as UI hints)
+> - Database schema (foundation still valid)
+> - LLM prompts (still applicable)
 
 ---
 

--- a/docs/plans/2025-12-31-phase-7.2-selenechat-planning-design.md
+++ b/docs/plans/2025-12-31-phase-7.2-selenechat-planning-design.md
@@ -1,8 +1,27 @@
 # Phase 7.2: SeleneChat Planning Integration
 
-**Status:** Design Complete
+**Status:** Design Revised (see below)
 **Created:** 2025-12-31
+**Revised:** 2026-01-02
 **Author:** Chase Easterling + Claude
+
+---
+
+> **⚠️ DESIGN REVISION (2026-01-02)**
+>
+> This design has been significantly revised. The key changes:
+> - **All notes go to Inbox** - No auto-routing based on classification
+> - **User confirms all tasks** - Nothing goes to Things without approval
+> - **Active/Parked structure** - Prevents overwhelm in planning view
+> - **Buttons-first triage** - Quick actions, conversation only when needed
+>
+> **See:** `docs/plans/2026-01-02-planning-inbox-redesign.md` for the current design.
+>
+> The sections below remain useful for:
+> - Claude API integration details
+> - Things URL scheme reference
+> - Methodology file structure
+> - Planning conversation flow (still applies within projects)
 
 ---
 

--- a/docs/plans/2026-01-02-planning-inbox-implementation.md
+++ b/docs/plans/2026-01-02-planning-inbox-implementation.md
@@ -1,0 +1,1792 @@
+# Planning Inbox Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build the Inbox triage system where ALL notes go through SeleneChat for user review before any tasks are created.
+
+**Architecture:** Three-section Planning tab (Inbox, Active, Parked) with triage buttons on note cards. Database stores project state, Swift services manage data, SwiftUI views provide ADHD-optimized UI.
+
+**Tech Stack:** SQLite migrations, Swift 5.9+, SwiftUI, SQLite.swift
+
+---
+
+## Implementation Overview
+
+| Task | Component | Estimated Steps |
+|------|-----------|-----------------|
+| 1 | Database Migration | 10 |
+| 2 | Swift Models | 8 |
+| 3 | Swift Migration | 8 |
+| 4 | InboxService | 12 |
+| 5 | ProjectService | 14 |
+| 6 | NoteType Badge Logic | 6 |
+| 7 | TriageCardView | 10 |
+| 8 | QuickTaskConfirmation | 8 |
+| 9 | InboxView | 10 |
+| 10 | ActiveProjectsList | 8 |
+| 11 | ParkedProjectsList | 6 |
+| 12 | PlanningView Refactor | 12 |
+| 13 | Integration Testing | 10 |
+
+---
+
+## Task 1: Database Migration
+
+**Files:**
+- Create: `database/migrations/011_planning_inbox.sql`
+
+**Step 1: Create migration file with projects table**
+
+```sql
+-- 011_planning_inbox.sql
+-- Phase 7: Planning Inbox Redesign
+-- Creates projects table, project_notes junction, and modifies raw_notes
+
+-- Projects table for Active/Parked structure
+CREATE TABLE IF NOT EXISTS projects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    status TEXT DEFAULT 'parked'
+        CHECK(status IN ('active', 'parked', 'completed')),
+    primary_concept TEXT,
+    things_project_id TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    last_active_at TEXT,
+    completed_at TEXT,
+    test_run TEXT DEFAULT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);
+CREATE INDEX IF NOT EXISTS idx_projects_test_run ON projects(test_run);
+```
+
+**Step 2: Add project_notes junction table**
+
+```sql
+-- Junction table linking projects to notes
+CREATE TABLE IF NOT EXISTS project_notes (
+    project_id INTEGER NOT NULL,
+    raw_note_id INTEGER NOT NULL,
+    attached_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (project_id, raw_note_id),
+    FOREIGN KEY (project_id) REFERENCES projects(id),
+    FOREIGN KEY (raw_note_id) REFERENCES raw_notes(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_notes_project ON project_notes(project_id);
+CREATE INDEX IF NOT EXISTS idx_project_notes_note ON project_notes(raw_note_id);
+```
+
+**Step 3: Add raw_notes columns for inbox tracking**
+
+```sql
+-- Add inbox tracking columns to raw_notes
+-- inbox_status: pending (new), triaged (processed), archived (hidden)
+-- suggested_type: AI hint for triage (quick_task, relates_to_project, new_project, reflection)
+-- suggested_project_id: If relates_to_project, which project
+
+ALTER TABLE raw_notes ADD COLUMN inbox_status TEXT DEFAULT 'pending'
+    CHECK(inbox_status IN ('pending', 'triaged', 'archived'));
+
+ALTER TABLE raw_notes ADD COLUMN suggested_type TEXT
+    CHECK(suggested_type IN ('quick_task', 'relates_to_project', 'new_project', 'reflection'));
+
+ALTER TABLE raw_notes ADD COLUMN suggested_project_id INTEGER
+    REFERENCES projects(id);
+
+CREATE INDEX IF NOT EXISTS idx_raw_notes_inbox_status ON raw_notes(inbox_status);
+```
+
+**Step 4: Run migration on test database to verify syntax**
+
+Run: `sqlite3 :memory: < database/migrations/011_planning_inbox.sql`
+Expected: No errors, tables created
+
+**Step 5: Commit database migration**
+
+```bash
+git add database/migrations/011_planning_inbox.sql
+git commit -m "feat(db): add planning inbox schema
+
+- projects table with status (active/parked/completed)
+- project_notes junction table
+- raw_notes inbox columns (inbox_status, suggested_type, suggested_project_id)"
+```
+
+---
+
+## Task 2: Swift Models
+
+**Files:**
+- Create: `SeleneChat/Sources/Models/Project.swift`
+- Create: `SeleneChat/Sources/Models/InboxNote.swift`
+- Create: `SeleneChat/Sources/Models/NoteType.swift`
+
+**Step 1: Create NoteType enum**
+
+```swift
+// SeleneChat/Sources/Models/NoteType.swift
+import Foundation
+
+enum NoteType: String, CaseIterable, Codable {
+    case quickTask = "quick_task"
+    case relatesToProject = "relates_to_project"
+    case newProject = "new_project"
+    case reflection = "reflection"
+
+    var displayName: String {
+        switch self {
+        case .quickTask: return "Quick task"
+        case .relatesToProject: return "Relates to project"
+        case .newProject: return "New project idea"
+        case .reflection: return "Reflection"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .quickTask: return "checklist"
+        case .relatesToProject: return "link"
+        case .newProject: return "plus.rectangle.on.folder"
+        case .reflection: return "bubble.left.and.text.bubble.right"
+        }
+    }
+
+    var emoji: String {
+        switch self {
+        case .quickTask: return "📋"
+        case .relatesToProject: return "🔗"
+        case .newProject: return "🆕"
+        case .reflection: return "💭"
+        }
+    }
+}
+```
+
+**Step 2: Run tests (should compile)**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 3: Create Project model**
+
+```swift
+// SeleneChat/Sources/Models/Project.swift
+import Foundation
+
+struct Project: Identifiable, Hashable {
+    let id: Int
+    var name: String
+    var status: Status
+    var primaryConcept: String?
+    var thingsProjectId: String?
+    let createdAt: Date
+    var lastActiveAt: Date?
+    var completedAt: Date?
+    var testRun: String?
+
+    // Computed from joins
+    var noteCount: Int = 0
+    var taskCount: Int = 0
+    var completedTaskCount: Int = 0
+
+    enum Status: String, CaseIterable {
+        case active
+        case parked
+        case completed
+
+        var icon: String {
+            switch self {
+            case .active: return "flame"
+            case .parked: return "parkingsign"
+            case .completed: return "checkmark.circle"
+            }
+        }
+
+        var color: String {
+            switch self {
+            case .active: return "orange"
+            case .parked: return "gray"
+            case .completed: return "green"
+            }
+        }
+    }
+
+    var timeSinceActive: String? {
+        guard let lastActive = lastActiveAt else { return nil }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: lastActive, relativeTo: Date())
+    }
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 5: Create InboxNote model**
+
+```swift
+// SeleneChat/Sources/Models/InboxNote.swift
+import Foundation
+
+struct InboxNote: Identifiable, Hashable {
+    let id: Int
+    let title: String
+    let content: String
+    let createdAt: Date
+
+    // Inbox-specific
+    var inboxStatus: InboxStatus
+    var suggestedType: NoteType?
+    var suggestedProjectId: Int?
+    var suggestedProjectName: String?
+
+    // From processed_notes
+    var concepts: [String]?
+    var primaryTheme: String?
+    var energyLevel: String?
+
+    enum InboxStatus: String {
+        case pending
+        case triaged
+        case archived
+    }
+
+    var preview: String {
+        String(content.prefix(150))
+    }
+
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: createdAt)
+    }
+}
+```
+
+**Step 6: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 7: Commit models**
+
+```bash
+git add SeleneChat/Sources/Models/NoteType.swift
+git add SeleneChat/Sources/Models/Project.swift
+git add SeleneChat/Sources/Models/InboxNote.swift
+git commit -m "feat(models): add Project, InboxNote, NoteType for planning inbox"
+```
+
+---
+
+## Task 3: Swift Database Migration
+
+**Files:**
+- Create: `SeleneChat/Sources/Services/Migrations/Migration002_PlanningInbox.swift`
+- Modify: `SeleneChat/Sources/Services/DatabaseService.swift:99` (add migration call)
+
+**Step 1: Create Swift migration**
+
+```swift
+// Migration002_PlanningInbox.swift
+// SeleneChat
+//
+// Created for Phase 7: Planning Inbox Redesign
+// Creates projects table and adds inbox columns to raw_notes
+
+import Foundation
+import SQLite
+
+struct Migration002_PlanningInbox {
+    static func run(db: Connection) throws {
+        // Create projects table
+        try db.run("""
+            CREATE TABLE IF NOT EXISTS projects (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                status TEXT DEFAULT 'parked'
+                    CHECK(status IN ('active', 'parked', 'completed')),
+                primary_concept TEXT,
+                things_project_id TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                last_active_at TEXT,
+                completed_at TEXT,
+                test_run TEXT DEFAULT NULL
+            )
+        """)
+
+        try db.run("CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status)")
+        try db.run("CREATE INDEX IF NOT EXISTS idx_projects_test_run ON projects(test_run)")
+
+        // Create project_notes junction table
+        try db.run("""
+            CREATE TABLE IF NOT EXISTS project_notes (
+                project_id INTEGER NOT NULL,
+                raw_note_id INTEGER NOT NULL,
+                attached_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (project_id, raw_note_id),
+                FOREIGN KEY (project_id) REFERENCES projects(id),
+                FOREIGN KEY (raw_note_id) REFERENCES raw_notes(id)
+            )
+        """)
+
+        try db.run("CREATE INDEX IF NOT EXISTS idx_project_notes_project ON project_notes(project_id)")
+        try db.run("CREATE INDEX IF NOT EXISTS idx_project_notes_note ON project_notes(raw_note_id)")
+
+        // Add inbox columns to raw_notes (ignore if already exist)
+        do {
+            try db.run("ALTER TABLE raw_notes ADD COLUMN inbox_status TEXT DEFAULT 'pending'")
+        } catch {
+            // Column may already exist
+        }
+
+        do {
+            try db.run("ALTER TABLE raw_notes ADD COLUMN suggested_type TEXT")
+        } catch {
+            // Column may already exist
+        }
+
+        do {
+            try db.run("ALTER TABLE raw_notes ADD COLUMN suggested_project_id INTEGER")
+        } catch {
+            // Column may already exist
+        }
+
+        try db.run("CREATE INDEX IF NOT EXISTS idx_raw_notes_inbox_status ON raw_notes(inbox_status)")
+
+        print("Migration 002: Planning inbox tables created")
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 3: Add migration call to DatabaseService**
+
+In `DatabaseService.swift`, find line ~98-99 where migrations run, add:
+
+```swift
+try? Migration002_PlanningInbox.run(db: db!)
+```
+
+**Step 4: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 5: Commit migration**
+
+```bash
+git add SeleneChat/Sources/Services/Migrations/Migration002_PlanningInbox.swift
+git add SeleneChat/Sources/Services/DatabaseService.swift
+git commit -m "feat(db): add Swift migration for planning inbox tables"
+```
+
+---
+
+## Task 4: InboxService
+
+**Files:**
+- Create: `SeleneChat/Sources/Services/InboxService.swift`
+
+**Step 1: Create service with column definitions**
+
+```swift
+// SeleneChat/Sources/Services/InboxService.swift
+import Foundation
+import SQLite
+
+class InboxService: ObservableObject {
+    static let shared = InboxService()
+
+    private var db: Connection?
+
+    // Table references
+    private let rawNotes = Table("raw_notes")
+    private let processedNotes = Table("processed_notes")
+    private let projects = Table("projects")
+
+    // raw_notes columns
+    private let noteId = Expression<Int64>("id")
+    private let noteTitle = Expression<String>("title")
+    private let noteContent = Expression<String>("content")
+    private let noteCreatedAt = Expression<String>("created_at")
+    private let inboxStatus = Expression<String?>("inbox_status")
+    private let suggestedType = Expression<String?>("suggested_type")
+    private let suggestedProjectId = Expression<Int64?>("suggested_project_id")
+    private let testRun = Expression<String?>("test_run")
+
+    // processed_notes columns
+    private let rawNoteId = Expression<Int64>("raw_note_id")
+    private let concepts = Expression<String?>("concepts")
+    private let primaryTheme = Expression<String?>("primary_theme")
+    private let energyLevel = Expression<String?>("energy_level")
+
+    // projects columns
+    private let projectId = Expression<Int64>("id")
+    private let projectName = Expression<String>("name")
+
+    init() {}
+
+    func configure(with db: Connection) {
+        self.db = db
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 3: Add getPendingNotes method**
+
+```swift
+// Add to InboxService
+
+func getPendingNotes() async throws -> [InboxNote] {
+    guard let db = db else {
+        throw DatabaseService.DatabaseError.notConnected
+    }
+
+    let query = rawNotes
+        .join(.leftOuter, processedNotes, on: rawNotes[noteId] == processedNotes[rawNoteId])
+        .join(.leftOuter, projects, on: rawNotes[suggestedProjectId] == projects[projectId])
+        .filter(rawNotes[inboxStatus] == "pending" || rawNotes[inboxStatus] == nil)
+        .filter(rawNotes[testRun] == nil)
+        .order(rawNotes[noteCreatedAt].desc)
+        .limit(50)
+
+    var notes: [InboxNote] = []
+
+    for row in try db.prepare(query) {
+        let note = try parseInboxNote(from: row)
+        notes.append(note)
+    }
+
+    return notes
+}
+
+private func parseInboxNote(from row: Row) throws -> InboxNote {
+    let dateFormatter = ISO8601DateFormatter()
+
+    // Parse concepts JSON
+    var conceptsArray: [String]? = nil
+    if let conceptsStr = try? row.get(processedNotes[concepts]),
+       let data = conceptsStr.data(using: .utf8) {
+        conceptsArray = try? JSONDecoder().decode([String].self, from: data)
+    }
+
+    // Parse suggested type
+    var noteType: NoteType? = nil
+    if let typeStr = try? row.get(rawNotes[suggestedType]) {
+        noteType = NoteType(rawValue: typeStr)
+    }
+
+    return InboxNote(
+        id: Int(try row.get(rawNotes[noteId])),
+        title: try row.get(rawNotes[noteTitle]),
+        content: try row.get(rawNotes[noteContent]),
+        createdAt: dateFormatter.date(from: try row.get(rawNotes[noteCreatedAt])) ?? Date(),
+        inboxStatus: .pending,
+        suggestedType: noteType,
+        suggestedProjectId: (try? row.get(rawNotes[suggestedProjectId])).map { Int($0) },
+        suggestedProjectName: try? row.get(projects[projectName]),
+        concepts: conceptsArray,
+        primaryTheme: try? row.get(processedNotes[primaryTheme]),
+        energyLevel: try? row.get(processedNotes[energyLevel])
+    )
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 5: Add triage action methods**
+
+```swift
+// Add to InboxService
+
+func markTriaged(noteId: Int) async throws {
+    guard let db = db else {
+        throw DatabaseService.DatabaseError.notConnected
+    }
+
+    let note = rawNotes.filter(self.noteId == Int64(noteId))
+    try db.run(note.update(inboxStatus <- "triaged"))
+}
+
+func markArchived(noteId: Int) async throws {
+    guard let db = db else {
+        throw DatabaseService.DatabaseError.notConnected
+    }
+
+    let note = rawNotes.filter(self.noteId == Int64(noteId))
+    try db.run(note.update(inboxStatus <- "archived"))
+}
+
+func attachToProject(noteId: Int, projectId: Int) async throws {
+    guard let db = db else {
+        throw DatabaseService.DatabaseError.notConnected
+    }
+
+    // Insert into project_notes
+    let projectNotes = Table("project_notes")
+    let projectIdCol = Expression<Int64>("project_id")
+    let rawNoteIdCol = Expression<Int64>("raw_note_id")
+
+    try db.run(projectNotes.insert(or: .ignore,
+        projectIdCol <- Int64(projectId),
+        rawNoteIdCol <- Int64(noteId)
+    ))
+
+    // Mark note as triaged
+    try await markTriaged(noteId: noteId)
+}
+```
+
+**Step 6: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 7: Commit InboxService**
+
+```bash
+git add SeleneChat/Sources/Services/InboxService.swift
+git commit -m "feat(service): add InboxService for inbox note management"
+```
+
+---
+
+## Task 5: ProjectService
+
+**Files:**
+- Create: `SeleneChat/Sources/Services/ProjectService.swift`
+
+**Step 1: Create service with column definitions**
+
+```swift
+// SeleneChat/Sources/Services/ProjectService.swift
+import Foundation
+import SQLite
+
+class ProjectService: ObservableObject {
+    static let shared = ProjectService()
+
+    private var db: Connection?
+
+    // Table references
+    private let projects = Table("projects")
+    private let projectNotes = Table("project_notes")
+
+    // projects columns
+    private let projectId = Expression<Int64>("id")
+    private let projectName = Expression<String>("name")
+    private let projectStatus = Expression<String>("status")
+    private let primaryConcept = Expression<String?>("primary_concept")
+    private let thingsProjectId = Expression<String?>("things_project_id")
+    private let createdAt = Expression<String>("created_at")
+    private let lastActiveAt = Expression<String?>("last_active_at")
+    private let completedAt = Expression<String?>("completed_at")
+    private let testRun = Expression<String?>("test_run")
+
+    // project_notes columns
+    private let pnProjectId = Expression<Int64>("project_id")
+    private let pnRawNoteId = Expression<Int64>("raw_note_id")
+
+    private let maxActiveProjects = 5
+
+    init() {}
+
+    func configure(with db: Connection) {
+        self.db = db
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 3: Add getActiveProjects method**
+
+```swift
+// Add to ProjectService
+
+func getActiveProjects() async throws -> [Project] {
+    guard let db = db else {
+        throw DatabaseService.DatabaseError.notConnected
+    }
+
+    let query = projects
+        .filter(projectStatus == "active")
+        .filter(testRun == nil)
+        .order(lastActiveAt.desc)
+
+    var projectList: [Project] = []
+
+    for row in try db.prepare(query) {
+        var project = try parseProject(from: row)
+        project.noteCount = try await getNoteCount(for: project.id)
+        projectList.append(project)
+    }
+
+    return projectList
+}
+
+func getParkedProjects() async throws -> [Project] {
+    guard let db = db else {
+        throw DatabaseService.DatabaseError.notConnected
+    }
+
+    let query = projects
+        .filter(projectStatus == "parked")
+        .filter(testRun == nil)
+        .order(lastActiveAt.desc)
+
+    var projectList: [Project] = []
+
+    for row in try db.prepare(query) {
+        var project = try parseProject(from: row)
+        project.noteCount = try await getNoteCount(for: project.id)
+        projectList.append(project)
+    }
+
+    return projectList
+}
+
+private func getNoteCount(for projectIdValue: Int) async throws -> Int {
+    guard let db = db else { return 0 }
+
+    let count = try db.scalar(
+        projectNotes.filter(pnProjectId == Int64(projectIdValue)).count
+    )
+    return count
+}
+
+private func parseProject(from row: Row) throws -> Project {
+    let dateFormatter = ISO8601DateFormatter()
+
+    return Project(
+        id: Int(try row.get(projectId)),
+        name: try row.get(projectName),
+        status: Project.Status(rawValue: try row.get(projectStatus)) ?? .parked,
+        primaryConcept: try? row.get(primaryConcept),
+        thingsProjectId: try? row.get(thingsProjectId),
+        createdAt: dateFormatter.date(from: try row.get(createdAt)) ?? Date(),
+        lastActiveAt: (try? row.get(lastActiveAt)).flatMap { dateFormatter.date(from: $0) },
+        completedAt: (try? row.get(completedAt)).flatMap { dateFormatter.date(from: $0) },
+        testRun: try? row.get(testRun)
+    )
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 5: Add createProject method**
+
+```swift
+// Add to ProjectService
+
+func createProject(name: String, fromNoteId: Int? = nil, concept: String? = nil) async throws -> Project {
+    guard let db = db else {
+        throw DatabaseService.DatabaseError.notConnected
+    }
+
+    let dateFormatter = ISO8601DateFormatter()
+    let now = dateFormatter.string(from: Date())
+
+    let id = try db.run(projects.insert(
+        projectName <- name,
+        projectStatus <- "parked",
+        primaryConcept <- concept,
+        createdAt <- now,
+        lastActiveAt <- now
+    ))
+
+    // If created from a note, attach it
+    if let noteId = fromNoteId {
+        try db.run(projectNotes.insert(
+            pnProjectId <- id,
+            pnRawNoteId <- Int64(noteId)
+        ))
+    }
+
+    return Project(
+        id: Int(id),
+        name: name,
+        status: .parked,
+        primaryConcept: concept,
+        thingsProjectId: nil,
+        createdAt: Date(),
+        lastActiveAt: Date(),
+        completedAt: nil,
+        testRun: nil,
+        noteCount: fromNoteId != nil ? 1 : 0
+    )
+}
+```
+
+**Step 6: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 7: Add status management methods**
+
+```swift
+// Add to ProjectService
+
+func activateProject(_ projectIdValue: Int) async throws {
+    guard let db = db else {
+        throw DatabaseService.DatabaseError.notConnected
+    }
+
+    // Check active count
+    let activeCount = try db.scalar(
+        projects.filter(projectStatus == "active").filter(testRun == nil).count
+    )
+
+    if activeCount >= maxActiveProjects {
+        throw ProjectError.tooManyActive
+    }
+
+    let dateFormatter = ISO8601DateFormatter()
+    let now = dateFormatter.string(from: Date())
+
+    let project = projects.filter(projectId == Int64(projectIdValue))
+    try db.run(project.update(
+        projectStatus <- "active",
+        lastActiveAt <- now
+    ))
+}
+
+func parkProject(_ projectIdValue: Int) async throws {
+    guard let db = db else {
+        throw DatabaseService.DatabaseError.notConnected
+    }
+
+    let project = projects.filter(projectId == Int64(projectIdValue))
+    try db.run(project.update(projectStatus <- "parked"))
+}
+
+func completeProject(_ projectIdValue: Int) async throws {
+    guard let db = db else {
+        throw DatabaseService.DatabaseError.notConnected
+    }
+
+    let dateFormatter = ISO8601DateFormatter()
+    let now = dateFormatter.string(from: Date())
+
+    let project = projects.filter(projectId == Int64(projectIdValue))
+    try db.run(project.update(
+        projectStatus <- "completed",
+        completedAt <- now
+    ))
+}
+
+enum ProjectError: Error, LocalizedError {
+    case tooManyActive
+
+    var errorDescription: String? {
+        switch self {
+        case .tooManyActive:
+            return "Maximum 5 active projects. Park one first."
+        }
+    }
+}
+```
+
+**Step 8: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 9: Commit ProjectService**
+
+```bash
+git add SeleneChat/Sources/Services/ProjectService.swift
+git commit -m "feat(service): add ProjectService for active/parked project management"
+```
+
+---
+
+## Task 6: TriageCardView
+
+**Files:**
+- Create: `SeleneChat/Sources/Views/Planning/TriageCardView.swift`
+
+**Step 1: Create view with basic layout**
+
+```swift
+// SeleneChat/Sources/Views/Planning/TriageCardView.swift
+import SwiftUI
+
+struct TriageCardView: View {
+    let note: InboxNote
+    let onCreateTask: () -> Void
+    let onAddToProject: () -> Void
+    let onStartProject: () -> Void
+    let onPark: () -> Void
+    let onArchive: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Type badge and date
+            HStack {
+                typeBadge
+                Spacer()
+                Text(note.formattedDate)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            // Note content
+            Text(note.title)
+                .font(.headline)
+                .lineLimit(1)
+
+            Text(note.preview)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+
+            // Suggested project (if relates_to_project)
+            if let projectName = note.suggestedProjectName {
+                HStack(spacing: 4) {
+                    Image(systemName: "link")
+                        .font(.caption)
+                    Text(projectName)
+                        .font(.caption)
+                        .foregroundColor(.accentColor)
+                }
+            }
+
+            // Action buttons
+            actionButtons
+        }
+        .padding()
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(12)
+    }
+
+    @ViewBuilder
+    private var typeBadge: some View {
+        if let type = note.suggestedType {
+            HStack(spacing: 4) {
+                Text(type.emoji)
+                Text(type.displayName)
+            }
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color.accentColor.opacity(0.1))
+            .cornerRadius(6)
+        }
+    }
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        HStack(spacing: 8) {
+            // Primary actions based on type
+            if note.suggestedType == .quickTask {
+                Button("Create Task") { onCreateTask() }
+                    .buttonStyle(.borderedProminent)
+            } else if note.suggestedType == .relatesToProject {
+                Button("Add to Project") { onAddToProject() }
+                    .buttonStyle(.borderedProminent)
+            } else {
+                Button("Start Project") { onStartProject() }
+                    .buttonStyle(.borderedProminent)
+            }
+
+            Button("Park") { onPark() }
+                .buttonStyle(.bordered)
+
+            Button(action: onArchive) {
+                Image(systemName: "archivebox")
+            }
+            .buttonStyle(.bordered)
+        }
+        .font(.caption)
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 3: Commit TriageCardView**
+
+```bash
+mkdir -p SeleneChat/Sources/Views/Planning
+git add SeleneChat/Sources/Views/Planning/TriageCardView.swift
+git commit -m "feat(ui): add TriageCardView for inbox note triage"
+```
+
+---
+
+## Task 7: QuickTaskConfirmation
+
+**Files:**
+- Create: `SeleneChat/Sources/Views/Planning/QuickTaskConfirmation.swift`
+
+**Step 1: Create confirmation sheet view**
+
+```swift
+// SeleneChat/Sources/Views/Planning/QuickTaskConfirmation.swift
+import SwiftUI
+
+struct QuickTaskConfirmation: View {
+    let note: InboxNote
+    let onConfirm: (String) -> Void
+    let onCancel: () -> Void
+
+    @State private var taskText: String
+    @State private var isSubmitting = false
+
+    init(note: InboxNote, onConfirm: @escaping (String) -> Void, onCancel: @escaping () -> Void) {
+        self.note = note
+        self.onConfirm = onConfirm
+        self.onCancel = onCancel
+        // Initialize with note title as default task text
+        _taskText = State(initialValue: note.title)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Header
+            HStack {
+                Text("📋")
+                Text("Quick task")
+                    .font(.headline)
+                Spacer()
+                Button(action: onCancel) {
+                    Image(systemName: "xmark")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Divider()
+
+            // Original note
+            VStack(alignment: .leading, spacing: 4) {
+                Text("From note:")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Text(note.preview)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+            }
+
+            // Editable task text
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Task to create:")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                TextField("Task text", text: $taskText, axis: .vertical)
+                    .textFieldStyle(.roundedBorder)
+                    .lineLimit(1...3)
+            }
+
+            Divider()
+
+            // Actions
+            HStack {
+                Spacer()
+
+                Button("Cancel") {
+                    onCancel()
+                }
+                .keyboardShortcut(.escape)
+
+                Button("Send to Things") {
+                    isSubmitting = true
+                    onConfirm(taskText)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(taskText.isEmpty || isSubmitting)
+                .keyboardShortcut(.return)
+            }
+        }
+        .padding()
+        .frame(width: 400)
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 3: Commit QuickTaskConfirmation**
+
+```bash
+git add SeleneChat/Sources/Views/Planning/QuickTaskConfirmation.swift
+git commit -m "feat(ui): add QuickTaskConfirmation sheet for task creation"
+```
+
+---
+
+## Task 8: InboxView
+
+**Files:**
+- Create: `SeleneChat/Sources/Views/Planning/InboxView.swift`
+
+**Step 1: Create InboxView with state**
+
+```swift
+// SeleneChat/Sources/Views/Planning/InboxView.swift
+import SwiftUI
+
+struct InboxView: View {
+    @EnvironmentObject var databaseService: DatabaseService
+    @StateObject private var inboxService = InboxService.shared
+    @StateObject private var projectService = ProjectService.shared
+
+    @State private var notes: [InboxNote] = []
+    @State private var isLoading = true
+    @State private var error: String?
+
+    @State private var selectedNoteForTask: InboxNote?
+    @State private var showTaskConfirmation = false
+
+    private let thingsService = ThingsURLService.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Section header
+            HStack {
+                Image(systemName: "tray.and.arrow.down")
+                Text("Inbox")
+                    .font(.headline)
+
+                if !notes.isEmpty {
+                    Text("(\(notes.count))")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                Button(action: { Task { await loadNotes() } }) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.caption)
+                }
+                .buttonStyle(.plain)
+                .disabled(isLoading)
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            // Content
+            if isLoading {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                .padding()
+            } else if notes.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(notes) { note in
+                            TriageCardView(
+                                note: note,
+                                onCreateTask: { startTaskCreation(for: note) },
+                                onAddToProject: { addToProject(note) },
+                                onStartProject: { startProject(from: note) },
+                                onPark: { parkNote(note) },
+                                onArchive: { archiveNote(note) }
+                            )
+                        }
+                    }
+                    .padding()
+                }
+            }
+        }
+        .task {
+            await loadNotes()
+        }
+        .sheet(isPresented: $showTaskConfirmation) {
+            if let note = selectedNoteForTask {
+                QuickTaskConfirmation(
+                    note: note,
+                    onConfirm: { taskText in
+                        Task { await createTask(taskText, from: note) }
+                    },
+                    onCancel: { showTaskConfirmation = false }
+                )
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.circle")
+                .font(.system(size: 40))
+                .foregroundColor(.green)
+            Text("Inbox clear!")
+                .font(.headline)
+            Text("New notes will appear here for triage")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+    }
+
+    private func loadNotes() async {
+        isLoading = true
+        error = nil
+
+        do {
+            notes = try await inboxService.getPendingNotes()
+        } catch {
+            self.error = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    private func startTaskCreation(for note: InboxNote) {
+        selectedNoteForTask = note
+        showTaskConfirmation = true
+    }
+
+    private func createTask(_ taskText: String, from note: InboxNote) async {
+        do {
+            try await thingsService.createTask(
+                title: taskText,
+                notes: nil,
+                tags: [],
+                energy: note.energyLevel,
+                sourceNoteId: note.id,
+                threadId: nil
+            )
+            try await inboxService.markTriaged(noteId: note.id)
+            await loadNotes()
+        } catch {
+            self.error = error.localizedDescription
+        }
+
+        showTaskConfirmation = false
+        selectedNoteForTask = nil
+    }
+
+    private func addToProject(_ note: InboxNote) {
+        // TODO: Show project picker
+        // For now, if suggested project exists, use that
+        if let projectId = note.suggestedProjectId {
+            Task {
+                try? await inboxService.attachToProject(noteId: note.id, projectId: projectId)
+                await loadNotes()
+            }
+        }
+    }
+
+    private func startProject(from note: InboxNote) {
+        Task {
+            do {
+                let _ = try await projectService.createProject(
+                    name: note.title,
+                    fromNoteId: note.id,
+                    concept: note.concepts?.first
+                )
+                try await inboxService.markTriaged(noteId: note.id)
+                await loadNotes()
+            } catch {
+                self.error = error.localizedDescription
+            }
+        }
+    }
+
+    private func parkNote(_ note: InboxNote) {
+        Task {
+            try? await inboxService.markTriaged(noteId: note.id)
+            await loadNotes()
+        }
+    }
+
+    private func archiveNote(_ note: InboxNote) {
+        Task {
+            try? await inboxService.markArchived(noteId: note.id)
+            await loadNotes()
+        }
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 3: Commit InboxView**
+
+```bash
+git add SeleneChat/Sources/Views/Planning/InboxView.swift
+git commit -m "feat(ui): add InboxView for note triage"
+```
+
+---
+
+## Task 9: ActiveProjectsList
+
+**Files:**
+- Create: `SeleneChat/Sources/Views/Planning/ActiveProjectsList.swift`
+
+**Step 1: Create ActiveProjectsList view**
+
+```swift
+// SeleneChat/Sources/Views/Planning/ActiveProjectsList.swift
+import SwiftUI
+
+struct ActiveProjectsList: View {
+    @StateObject private var projectService = ProjectService.shared
+
+    @State private var projects: [Project] = []
+    @State private var isLoading = true
+    @State private var error: String?
+
+    let onSelectProject: (Project) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Section header
+            HStack {
+                Image(systemName: "flame")
+                    .foregroundColor(.orange)
+                Text("Active")
+                    .font(.headline)
+
+                if !projects.isEmpty {
+                    Text("(\(projects.count))")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            // Content
+            if isLoading {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                .padding()
+            } else if projects.isEmpty {
+                emptyState
+            } else {
+                LazyVStack(spacing: 8) {
+                    ForEach(projects) { project in
+                        ProjectRowView(project: project)
+                            .onTapGesture { onSelectProject(project) }
+                    }
+                }
+                .padding()
+            }
+        }
+        .task {
+            await loadProjects()
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Text("No active projects")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Text("Start from inbox or activate a parked project")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+    }
+
+    private func loadProjects() async {
+        isLoading = true
+
+        do {
+            projects = try await projectService.getActiveProjects()
+        } catch {
+            self.error = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+}
+
+struct ProjectRowView: View {
+    let project: Project
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(project.name)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                HStack(spacing: 8) {
+                    Label("\(project.noteCount)", systemImage: "doc")
+                    if let time = project.timeSinceActive {
+                        Text(time)
+                    }
+                }
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(12)
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(8)
+        .contentShape(Rectangle())
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 3: Commit ActiveProjectsList**
+
+```bash
+git add SeleneChat/Sources/Views/Planning/ActiveProjectsList.swift
+git commit -m "feat(ui): add ActiveProjectsList for project display"
+```
+
+---
+
+## Task 10: ParkedProjectsList
+
+**Files:**
+- Create: `SeleneChat/Sources/Views/Planning/ParkedProjectsList.swift`
+
+**Step 1: Create ParkedProjectsList view**
+
+```swift
+// SeleneChat/Sources/Views/Planning/ParkedProjectsList.swift
+import SwiftUI
+
+struct ParkedProjectsList: View {
+    @StateObject private var projectService = ProjectService.shared
+
+    @State private var projects: [Project] = []
+    @State private var isLoading = true
+    @State private var isExpanded = false
+
+    let onSelectProject: (Project) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Section header (always visible)
+            Button(action: { withAnimation { isExpanded.toggle() } }) {
+                HStack {
+                    Image(systemName: "parkingsign")
+                        .foregroundColor(.gray)
+                    Text("Parked")
+                        .font(.headline)
+
+                    if !projects.isEmpty {
+                        Text("(\(projects.count))")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+
+                    Spacer()
+
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            if isExpanded {
+                Divider()
+
+                // Content
+                if isLoading {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }
+                    .padding()
+                } else if projects.isEmpty {
+                    Text("No parked projects")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                } else {
+                    LazyVStack(spacing: 8) {
+                        ForEach(projects) { project in
+                            ParkedProjectRow(
+                                project: project,
+                                onActivate: { activateProject(project) },
+                                onSelect: { onSelectProject(project) }
+                            )
+                        }
+                    }
+                    .padding()
+                }
+            }
+        }
+        .task {
+            await loadProjects()
+        }
+    }
+
+    private func loadProjects() async {
+        isLoading = true
+
+        do {
+            projects = try await projectService.getParkedProjects()
+        } catch {
+            // Handle error
+        }
+
+        isLoading = false
+    }
+
+    private func activateProject(_ project: Project) {
+        Task {
+            do {
+                try await projectService.activateProject(project.id)
+                await loadProjects()
+            } catch {
+                // Show error
+            }
+        }
+    }
+}
+
+struct ParkedProjectRow: View {
+    let project: Project
+    let onActivate: () -> Void
+    let onSelect: () -> Void
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(project.name)
+                    .font(.caption)
+
+                if let time = project.timeSinceActive {
+                    Text("Last active \(time)")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .onTapGesture { onSelect() }
+
+            Spacer()
+
+            Button("Activate") {
+                onActivate()
+            }
+            .font(.caption)
+            .buttonStyle(.bordered)
+        }
+        .padding(8)
+        .background(Color(NSColor.controlBackgroundColor).opacity(0.5))
+        .cornerRadius(6)
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 3: Commit ParkedProjectsList**
+
+```bash
+git add SeleneChat/Sources/Views/Planning/ParkedProjectsList.swift
+git commit -m "feat(ui): add ParkedProjectsList with expand/collapse"
+```
+
+---
+
+## Task 11: PlanningView Refactor
+
+**Files:**
+- Modify: `SeleneChat/Sources/Views/PlanningView.swift`
+
+**Step 1: Add service configuration to app startup**
+
+In `SeleneChatApp.swift` or `ContentView.swift`, configure services with database connection:
+
+```swift
+// Add after databaseService is created
+InboxService.shared.configure(with: databaseService.db!)
+ProjectService.shared.configure(with: databaseService.db!)
+```
+
+**Step 2: Refactor PlanningView to use three sections**
+
+Replace PlanningView body with:
+
+```swift
+struct PlanningView: View {
+    @EnvironmentObject var databaseService: DatabaseService
+
+    @State private var selectedThread: DiscussionThread?
+    @State private var selectedProject: Project?
+
+    var body: some View {
+        Group {
+            if let thread = selectedThread {
+                PlanningConversationView(
+                    thread: thread,
+                    onBack: { selectedThread = nil }
+                )
+            } else if let project = selectedProject {
+                ProjectDetailView(
+                    project: project,
+                    onBack: { selectedProject = nil }
+                )
+            } else {
+                mainPlanningView
+            }
+        }
+        .onAppear {
+            #if DEBUG
+            DebugLogger.shared.log(.nav, "Appeared: PlanningView")
+            ActionTracker.shared.track(action: "viewAppeared", params: ["view": "PlanningView"])
+            #endif
+        }
+    }
+
+    private var mainPlanningView: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Planning")
+                        .font(.title2)
+                        .fontWeight(.semibold)
+                }
+
+                Spacer()
+
+                Button(action: {}) {
+                    Image(systemName: "gearshape")
+                }
+                .buttonStyle(.plain)
+            }
+            .padding()
+
+            Divider()
+
+            // Three sections
+            ScrollView {
+                VStack(spacing: 20) {
+                    // Inbox section
+                    InboxView()
+
+                    Divider()
+                        .padding(.horizontal)
+
+                    // Active projects section
+                    ActiveProjectsList(onSelectProject: { project in
+                        selectedProject = project
+                    })
+
+                    Divider()
+                        .padding(.horizontal)
+
+                    // Parked projects section
+                    ParkedProjectsList(onSelectProject: { project in
+                        selectedProject = project
+                    })
+                }
+                .padding(.bottom)
+            }
+        }
+    }
+}
+
+// Placeholder for project detail
+struct ProjectDetailView: View {
+    let project: Project
+    let onBack: () -> Void
+
+    var body: some View {
+        VStack {
+            HStack {
+                Button(action: onBack) {
+                    Label("Back", systemImage: "chevron.left")
+                }
+                Spacer()
+                Text(project.name)
+                    .font(.headline)
+                Spacer()
+            }
+            .padding()
+
+            Text("Project detail view coming soon")
+                .foregroundColor(.secondary)
+
+            Spacer()
+        }
+    }
+}
+```
+
+**Step 3: Run tests**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 4: Commit PlanningView refactor**
+
+```bash
+git add SeleneChat/Sources/Views/PlanningView.swift
+git commit -m "refactor(ui): PlanningView with Inbox/Active/Parked sections"
+```
+
+---
+
+## Task 12: Integration Testing
+
+**Step 1: Create test script for database migration**
+
+```bash
+#!/bin/bash
+# test-planning-inbox-migration.sh
+
+DB_FILE=$(mktemp)
+sqlite3 "$DB_FILE" < database/schema.sql
+sqlite3 "$DB_FILE" < database/migrations/011_planning_inbox.sql
+
+# Verify tables
+echo "Checking projects table..."
+sqlite3 "$DB_FILE" "SELECT sql FROM sqlite_master WHERE name='projects';"
+
+echo "Checking project_notes table..."
+sqlite3 "$DB_FILE" "SELECT sql FROM sqlite_master WHERE name='project_notes';"
+
+echo "Checking raw_notes columns..."
+sqlite3 "$DB_FILE" "PRAGMA table_info(raw_notes);" | grep -E "(inbox_status|suggested_type|suggested_project_id)"
+
+rm "$DB_FILE"
+echo "Migration test passed!"
+```
+
+**Step 2: Run migration test**
+
+Run: `chmod +x test-planning-inbox-migration.sh && ./test-planning-inbox-migration.sh`
+Expected: All tables and columns exist
+
+**Step 3: Build and launch SeleneChat**
+
+Run: `cd SeleneChat && swift build && swift run`
+Expected: App launches, Planning tab shows three sections
+
+**Step 4: Manual test checklist**
+
+- [ ] Inbox section shows notes with inbox_status='pending'
+- [ ] Empty state shows when no pending notes
+- [ ] Triage buttons appear on cards
+- [ ] Quick task confirmation sheet opens
+- [ ] Active projects section loads (empty initially)
+- [ ] Parked projects section expands/collapses
+
+**Step 5: Commit test script**
+
+```bash
+git add test-planning-inbox-migration.sh
+git commit -m "test: add planning inbox migration test script"
+```
+
+---
+
+## Task 13: Update BRANCH-STATUS.md
+
+**Step 1: Mark planning complete**
+
+Update `BRANCH-STATUS.md`:
+
+```markdown
+### Planning
+- [x] Design doc exists and approved
+- [x] Conflict check completed (no overlapping work)
+- [x] Dependencies identified and noted
+- [x] Branch and worktree created
+- [x] Implementation plan written (superpowers:writing-plans)
+```
+
+**Step 2: Commit status update**
+
+```bash
+git add BRANCH-STATUS.md
+git commit -m "docs: mark planning stage complete"
+```
+
+---
+
+## Execution Summary
+
+Total tasks: 13
+Total steps: ~120
+
+**Suggested execution order:**
+1. Tasks 1-3 (Database) - Foundation
+2. Tasks 4-5 (Services) - Data layer
+3. Tasks 6-8 (Views: Cards) - UI components
+4. Tasks 9-11 (Views: Lists + Refactor) - Main UI
+5. Tasks 12-13 (Testing + Status) - Verification
+
+---
+
+**Plan complete and saved to `docs/plans/2026-01-02-planning-inbox-implementation.md`. Two execution options:**
+
+**1. Subagent-Driven (this session)** - I dispatch fresh subagent per task, review between tasks, fast iteration
+
+**2. Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/plans/2026-01-02-planning-inbox-redesign.md
+++ b/docs/plans/2026-01-02-planning-inbox-redesign.md
@@ -1,0 +1,410 @@
+# Planning Inbox Redesign
+
+**Status:** Approved
+**Created:** 2026-01-02
+**Author:** Chase Easterling + Claude
+**Supersedes:** Parts of Phase 7.1 and 7.2 designs
+
+---
+
+## Executive Summary
+
+This design revises the Phase 7 planning flow based on user story analysis. The key change: **ALL notes go through SeleneChat Inbox for user triage before any tasks are created.** No automatic task creation in Things.
+
+### Why This Change
+
+The original design auto-routed "actionable" notes directly to Things. Through discussion, we identified problems:
+
+1. **Inbox overwhelm** - Auto-created tasks fill Things without user buy-in
+2. **AI misinterpretation** - User can't verify the AI understood correctly
+3. **Missing context** - Even "simple" tasks benefit from a moment of reflection
+4. **Loss of control** - User doesn't decide what becomes a "real" task
+
+### Core Principle
+
+> The value isn't in "extracting tasks from notes" - it's in **having a conversation that produces a plan you actually understand and believe in.**
+
+---
+
+## Architecture Overview
+
+### Before (Original Design)
+
+```
+Note → Classify → Actionable? → Auto-create task in Things
+                → Needs planning? → Park in SeleneChat
+                → Archive only? → Obsidian
+```
+
+### After (This Design)
+
+```
+Note → Process/Enrich → ALL park in SeleneChat Inbox
+                              │
+                              ▼
+                        User Triage
+                              │
+          ┌───────────────────┼───────────────────┐
+          ▼                   ▼                   ▼
+     Quick Task          Start Project          Park
+          │                   │                   │
+          ▼                   ▼                   ▼
+    Confirm text →      Planning Conv →      Parked List
+    Things Inbox        Tasks → Things       (revisit later)
+```
+
+---
+
+## Planning Tab Structure
+
+### Three Sections
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Planning                                        ⚙️     │
+├─────────────────────────────────────────────────────────┤
+│                                                         │
+│  📥 Inbox (4)                                           │
+│  [New notes waiting for triage]                         │
+│                                                         │
+│  ─────────────────────────────────────────────────────  │
+│                                                         │
+│  🔥 Active (2)                                          │
+│  [Projects you're currently working on]                 │
+│                                                         │
+│  ─────────────────────────────────────────────────────  │
+│                                                         │
+│  🅿️ Parked (12)                              [View →]   │
+│  [Everything else - not deleted, just not in focus]     │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Active limit:** 3-5 projects max to force focus and prevent overwhelm.
+
+---
+
+## Inbox Triage UX
+
+### Note Type Detection
+
+AI analyzes each note and suggests a type:
+
+| Badge | Meaning | Primary Actions |
+|-------|---------|-----------------|
+| 📋 Quick task | Clear, simple action | Create Task, Park, Archive |
+| 🔗 Relates to project | Concept match found | Add to Project, New Project, Park |
+| 🆕 New project idea | Complex, needs planning | Start Project, Park, Archive |
+| 💭 Reflection | No action implied | Keep in Knowledge, Link to..., Archive |
+
+### Triage Card Layout
+
+```
+┌────────────────────────────────────────────────────────┐
+│ "Maybe use Astro for the blog section"                 │
+│ 🔗 Website Redesign (parked)                           │
+│                                                        │
+│ [Add to Project] [New Project] [Park] [Archive]        │
+└────────────────────────────────────────────────────────┘
+```
+
+### Action Behaviors
+
+| Action | What Happens |
+|--------|--------------|
+| **Create Task** | Shows confirmation with editable text → sends to Things |
+| **Add to Project** | Attaches immediately, clears from Inbox |
+| **Start Project** | Creates project with AI-generated name, opens planning conversation |
+| **Park** | Moves to Parked list (standalone or as future project idea) |
+| **Archive** | Stored in database/Obsidian, removed from Planning tab |
+| **Keep in Knowledge** | Searchable in SeleneChat, not actionable |
+| **Link to...** | Opens project picker to attach note as context |
+| **Discuss** | Opens conversation before deciding |
+
+### Quick Task Confirmation
+
+When tapping "Create Task":
+
+```
+┌────────────────────────────────────────────────────────┐
+│ "Call dentist about cleaning appointment"              │
+│ 📋 Quick task                                          │
+├────────────────────────────────────────────────────────┤
+│                                                        │
+│  Task to create:                                       │
+│  ┌──────────────────────────────────────────────────┐  │
+│  │ Call dentist about cleaning appointment          │  │
+│  └──────────────────────────────────────────────────┘  │
+│                                                        │
+│           [Send to Things ✓]    [Cancel]               │
+│                                                        │
+└────────────────────────────────────────────────────────┘
+```
+
+- Tap text to edit if needed
+- AI handles metadata (energy, time estimates)
+- Things handles scheduling
+
+---
+
+## Project Lifecycle
+
+### States
+
+```
+┌──────────┐    ┌──────────┐    ┌──────────┐
+│  Parked  │◄──►│  Active  │───►│ Complete │
+└──────────┘    └──────────┘    └──────────┘
+```
+
+- **Parked**: Not in focus, but not forgotten
+- **Active**: Currently working on (limited to 3-5)
+- **Complete**: All tasks done, archived
+
+### Context Memory
+
+When a new note relates to an existing project (even parked), the system preserves:
+
+1. **Conversation history** - All previous planning discussions
+2. **Accumulated notes** - Every note attached to the project
+3. **Task status** - Current state from Things (synced)
+4. **Decisions made** - So you don't re-litigate
+
+When reopening a parked project:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  ← Back                          Website Redesign       │
+├─────────────────────────────────────────────────────────┤
+│                                                         │
+│  📎 Project Context (tap to expand)                     │
+│     • 4 notes attached                                  │
+│     • 4 tasks (2 done, 2 pending)                       │
+│     • Last active: 3 weeks ago                          │
+│                                                         │
+│  ─────────────────────────────────────────────────────  │
+│                                                         │
+│  🆕 New note added:                                     │
+│  "Maybe use Astro for the blog section"                 │
+│                                                         │
+│  🤖 Welcome back to Website Redesign. You were          │
+│     researching hosting options last time.              │
+│                                                         │
+│     This new note is about tech stack for the blog.     │
+│     Want to explore this now, or just add it to         │
+│     your research list?                                 │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Classification Role Change
+
+### Before
+Classification determined routing:
+- `actionable` → Things (automatic)
+- `needs_planning` → SeleneChat
+- `archive_only` → Obsidian
+
+### After
+Classification becomes a **UI hint**:
+- Suggests note type badge in Inbox (📋, 🔗, 🆕, 💭)
+- Suggests related projects (concept matching)
+- Enriches metadata for future use
+- Does NOT auto-route anything
+
+### What Stays
+- Metadata extraction (concepts, themes, energy, overwhelm)
+- Database schema for classification
+- The LLM classification logic itself
+- Concept-based project matching
+
+---
+
+## Changes to Existing Components
+
+### Workflow 07 (Task Extraction)
+
+**Before:** Classifies notes, auto-creates tasks in Things for `actionable` items.
+
+**After:**
+- Still extracts metadata and classification
+- Stores everything in database
+- Does NOT talk to Things
+- Things integration moves to SeleneChat (user-initiated)
+
+### Phase 7.2 (SeleneChat Planning)
+
+**Before:** Planning tab shows only `needs_planning` items.
+
+**After:**
+- Planning tab gets Inbox section (all notes)
+- Adds Active/Parked structure
+- Triage UX with buttons (conversation optional)
+- "Quick task" path for simple items
+
+### Phase 7.2e (Bidirectional Things Flow)
+
+**Before:** Resurface triggers surface threads.
+
+**After:**
+- Same trigger logic
+- Triggers can promote from Parked to Active
+- Or surface within Active for review
+
+### Phase 7.2f (Project Grouping)
+
+**Before:** Auto-create Things projects from concept clusters.
+
+**After:**
+- Projects created in SeleneChat first (user-initiated)
+- Things projects created when tasks are sent
+- Concept clustering suggests "Add to Project" in Inbox
+
+---
+
+## New Swift Components Needed
+
+```
+SeleneChat/
+├── Views/
+│   ├── Planning/
+│   │   ├── PlanningView.swift          # Main tab (existing, modify)
+│   │   ├── InboxView.swift             # NEW: Inbox section
+│   │   ├── TriageCardView.swift        # NEW: Note card with actions
+│   │   ├── ActiveProjectsList.swift    # NEW: Active projects section
+│   │   ├── ParkedProjectsList.swift    # NEW: Parked projects section
+│   │   ├── QuickTaskConfirmation.swift # NEW: Task confirmation sheet
+│   │   └── PlanningConversationView.swift # Existing, keep
+│   │
+├── Services/
+│   ├── InboxService.swift              # NEW: Fetch/manage inbox notes
+│   ├── ProjectService.swift            # NEW: Active/Parked management
+│   └── ThingsURLService.swift          # Existing, keep
+│
+└── Models/
+    ├── InboxNote.swift                 # NEW: Note in inbox
+    ├── Project.swift                   # NEW: Project with state
+    └── NoteType.swift                  # NEW: Enum for note badges
+```
+
+---
+
+## Database Changes
+
+### New: projects table
+
+```sql
+CREATE TABLE projects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    status TEXT DEFAULT 'parked'
+        CHECK(status IN ('active', 'parked', 'completed')),
+    primary_concept TEXT,
+    things_project_id TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    last_active_at TEXT,
+    completed_at TEXT
+);
+```
+
+### New: project_notes junction
+
+```sql
+CREATE TABLE project_notes (
+    project_id INTEGER NOT NULL,
+    raw_note_id INTEGER NOT NULL,
+    attached_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (project_id, raw_note_id),
+    FOREIGN KEY (project_id) REFERENCES projects(id),
+    FOREIGN KEY (raw_note_id) REFERENCES raw_notes(id)
+);
+```
+
+### Modify: raw_notes
+
+```sql
+ALTER TABLE raw_notes ADD COLUMN inbox_status TEXT DEFAULT 'pending'
+    CHECK(inbox_status IN ('pending', 'triaged', 'archived'));
+ALTER TABLE raw_notes ADD COLUMN suggested_type TEXT
+    CHECK(suggested_type IN ('quick_task', 'relates_to_project', 'new_project', 'reflection'));
+ALTER TABLE raw_notes ADD COLUMN suggested_project_id INTEGER;
+```
+
+---
+
+## Future Features
+
+These were identified during brainstorming but are NOT part of initial implementation:
+
+### Parking Lot Rot Detection
+Surface parked items that haven't been touched in X days:
+```
+🕸️ "Career pivot ideas" hasn't been touched in 6 weeks
+   Still relevant?     [Reactivate] [Archive] [Snooze]
+```
+
+### AI Suggestions When Active Doesn't Appeal
+```
+🤖 "Nothing in Active clicking today?
+    Based on your energy and recent notes, you might
+    want to pick up 'Home Office Setup' - it's mostly
+    low-energy research tasks."
+```
+
+### Task Check-in Conversations
+```
+🤖 "You created 'Call dentist' 5 days ago but haven't
+    done it. This seemed important - what's getting
+    in the way?"
+
+👤 "I hate phone calls"
+
+🤖 "That's real. Would it help to:
+    - Schedule a specific time?
+    - Check for online booking?
+    - Just find the number first?"
+```
+
+### Explicit Project Suggestion Correction
+"Not this" button when AI suggests wrong project match.
+
+### Auto-Park Suggestions
+"You haven't touched this active project in 2 weeks - park it?"
+
+---
+
+## Success Criteria
+
+- [ ] All notes appear in Inbox (no auto-routing)
+- [ ] Triage buttons work for all note types
+- [ ] Quick task confirmation sends to Things correctly
+- [ ] Active/Parked distinction visible and manageable
+- [ ] Projects preserve context when reopened
+- [ ] New notes attach to existing projects correctly
+- [ ] User reports feeling in control of what becomes a task
+
+---
+
+## Implementation Priority
+
+1. **Inbox View** - Core triage experience
+2. **Active/Parked structure** - Project organization
+3. **Quick task flow** - Simple notes → Things
+4. **Project conversations** - Complex planning
+5. **Context memory** - Reopen with history
+
+---
+
+## Related Documents
+
+- [Original Task Extraction Design](./2025-12-30-task-extraction-planning-design.md) - Superseded for routing
+- [Phase 7.2 SeleneChat Planning](./2025-12-31-phase-7.2-selenechat-planning-design.md) - Being modified
+- [Phase 7 Roadmap](../roadmap/16-PHASE-7-THINGS.md) - Update needed
+- [Project Grouping Design](./2026-01-01-project-grouping-design.md) - Adjust for new model
+
+---
+
+**Document Status:** Approved
+**Next Step:** Create implementation plan with superpowers:writing-plans

--- a/docs/roadmap/16-PHASE-7-THINGS.md
+++ b/docs/roadmap/16-PHASE-7-THINGS.md
@@ -1,31 +1,35 @@
 # Phase 7: Things Integration
 
-**Status:** 🚧 Phase 7.1 Complete ✅ | Phase 7.2 Design Complete 📋
+**Status:** 🚧 Phase 7.1 Complete ✅ | Phase 7.2 Design Revised 📋
 **Started:** 2025-11-24
 **Phase 7.1 Completed:** 2025-12-30
-**Phase 7.2 Design:** 2025-12-31
-**Goal:** Integrate Selene with Things 3 via intelligent classification - AI triages notes and routes actionable items to Things
+**Phase 7.2 Design Revised:** 2026-01-02
+**Goal:** Integrate Selene with Things 3 via user-controlled planning - ALL notes go through SeleneChat for triage before any tasks are created
 
 ---
 
 ## Overview
 
-Phase 7 brings Selene's note processing intelligence into task management via **intelligent classification**. Local AI classifies every note and routes appropriately: clear tasks to Things, ambiguous items to SeleneChat for planning, and reflections to archive.
+> **DESIGN REVISION (2026-01-02):** The original auto-routing design has been replaced with a user-controlled triage model. See `docs/plans/2026-01-02-planning-inbox-redesign.md` for the complete revised design.
+
+Phase 7 brings Selene's note processing intelligence into task management via **user-controlled triage**. Local AI enriches every note with metadata and suggests categorization, but the **user decides** what becomes a task through SeleneChat's Inbox.
 
 **Key Innovation:**
-- **Classification-based triage:** Notes classified as actionable/needs_planning/archive_only
-- **Things inbox only:** Clear actionable tasks go directly to Things inbox (no projects)
-- **SeleneChat for planning:** Ambiguous items flagged for planning conversations
-- **Full metadata:** All notes get rich metadata regardless of classification
-- **Local AI first:** Phase 7.1-7.2 use only local Ollama (private), cloud AI added in Phase 7.3+
+- **No auto-routing:** ALL notes park in SeleneChat Inbox for user triage
+- **User confirms everything:** Tasks only created after user approval
+- **Active/Parked structure:** Prevents overwhelm in planning view
+- **Classification as hint:** AI suggests note type, user decides action
+- **Context memory:** Projects preserve history when reopened with new notes
 
-**Design Document:** See `docs/plans/2025-12-30-task-extraction-planning-design.md` for complete architecture.
+**Design Documents:**
+- **Current:** `docs/plans/2026-01-02-planning-inbox-redesign.md` (this design)
+- **Superseded:** `docs/plans/2025-12-30-task-extraction-planning-design.md` (auto-routing)
 
 ---
 
 ## Architecture
 
-### Architectural Layers
+### Architectural Layers (Revised 2026-01-02)
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -38,70 +42,98 @@ Phase 7 brings Selene's note processing intelligence into task management via **
 │                      PROCESSING LAYER (Local AI)                     │
 │                                                                      │
 │  ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐ │
-│  │ Extract Metadata │    │    Classify     │    │   Sanitize      │ │
-│  │ - concepts       │ →  │ - actionable    │ →  │ (for cloud AI)  │ │
-│  │ - themes         │    │ - needs_planning│    │ - context-based │ │
-│  │ - energy         │    │ - archive_only  │    │ - user rules    │ │
-│  │ - overwhelm      │    │                 │    │                 │ │
+│  │ Extract Metadata │    │  Classify       │    │  Suggest        │ │
+│  │ - concepts       │ →  │  (as UI hint)   │ →  │  - note type    │ │
+│  │ - themes         │    │ - actionable    │    │  - project link │ │
+│  │ - energy         │    │ - needs_planning│    │                 │ │
+│  │ - overwhelm      │    │ - archive_only  │    │                 │ │
 │  └─────────────────┘    └─────────────────┘    └─────────────────┘ │
 │                                                                      │
 │  Ollama (mistral:7b) - All processing stays local                   │
 └─────────────────────────────────────────────────────────────────────┘
                                    │
-                    ┌──────────────┼──────────────┐
-                    ▼              ▼              ▼
-            ┌───────────┐  ┌───────────┐  ┌───────────┐
-            │ ACTIONABLE│  │  NEEDS    │  │  ARCHIVE  │
-            │           │  │ PLANNING  │  │   ONLY    │
-            └─────┬─────┘  └─────┬─────┘  └─────┬─────┘
-                  │              │              │
-                  ▼              ▼              ▼
-            ┌───────────┐  ┌───────────┐  ┌───────────┐
-            │  Things   │  │ SeleneChat│  │  Obsidian │
-            │   Inbox   │  │  Planning │  │  Archive  │
-            └───────────┘  └───────────┘  └───────────┘
+                                   ▼
+                    ┌─────────────────────────────┐
+                    │     ALL NOTES PARK HERE     │
+                    │                             │
+                    │   SeleneChat Planning Tab   │
+                    │        📥 Inbox             │
+                    └─────────────┬───────────────┘
+                                  │
+                           USER TRIAGE
+                                  │
+          ┌───────────────────────┼───────────────────────┐
+          ▼                       ▼                       ▼
+    ┌───────────┐          ┌───────────┐          ┌───────────┐
+    │Create Task│          │  Start    │          │   Park    │
+    │(confirm)  │          │  Project  │          │           │
+    └─────┬─────┘          └─────┬─────┘          └─────┬─────┘
+          │                      │                      │
+          ▼                      ▼                      ▼
+    ┌───────────┐          ┌───────────┐          ┌───────────┐
+    │  Things   │          │ Planning  │          │  Parked   │
+    │   Inbox   │          │   Conv    │          │   List    │
+    └───────────┘          └─────┬─────┘          └───────────┘
+                                 │
+                                 ▼
+                           ┌───────────┐
+                           │  Tasks →  │
+                           │  Things   │
+                           └───────────┘
 ```
 
 ### AI Layer Responsibilities
 
 | Layer | Tool | Responsibilities |
 |-------|------|------------------|
-| **Local AI** | Ollama | Metadata extraction, classification, organization, archiving |
-| **Cloud AI** (Phase 7.3+) | External service | Planning, scoping, breakdown (with sanitization layer) |
-| **SeleneChat** | macOS app | Knowledge queries, topic discussion, planning sessions, thread continuation |
-| **Things** | Task manager | Receives clear actionable tasks only (no projects) |
+| **Local AI** | Ollama | Metadata extraction, classification (as hint), project matching |
+| **Cloud AI** (Phase 7.3+) | External service | Planning conversations, scoping, breakdown |
+| **SeleneChat** | macOS app | **All triage + planning** - Inbox, Active/Parked projects, conversations |
+| **Things** | Task manager | Receives tasks **only after user confirmation** |
 
-### Data Flow
+### Data Flow (Revised)
 
 1. **Note Capture** (existing): Drafts → n8n → SQLite
-2. **Metadata Extraction** (NEW): Ollama extracts concepts, themes, energy, overwhelm, task_type
-3. **Classification** (NEW): Ollama classifies as actionable/needs_planning/archive_only
-4. **Routing**:
-   - `actionable` → Things inbox (with metadata)
-   - `needs_planning` → Flagged for SeleneChat planning sessions
-   - `archive_only` → Obsidian export only
-5. **Planning Sessions** (Phase 7.2): SeleneChat facilitates breakdown of flagged items
-6. **Cloud AI** (Phase 7.3): Sanitized requests to external AI for complex planning
+2. **Metadata Extraction**: Ollama extracts concepts, themes, energy, overwhelm, task_type
+3. **Classification as Hint**: Ollama suggests type (quick_task, relates_to_project, new_project, reflection)
+4. **Park in Inbox**: ALL notes go to SeleneChat Inbox (no auto-routing)
+5. **User Triage**: User sees notes with suggested types, decides action:
+   - Create Task → Confirm text → Things
+   - Start Project → Planning conversation → Tasks
+   - Add to Project → Attach to existing project
+   - Park → Save for later
+   - Archive → Store but hide from Planning
+6. **Planning Conversations** (Phase 7.2): Guided breakdown produces tasks → Things
+7. **Cloud AI** (Phase 7.3): Sanitized requests for complex planning
 
 ---
 
 ## Sub-Phases
 
-### Phase 7.1: Task Extraction with Classification (Weeks 1-2)
+### Phase 7.1: Task Extraction with Classification (Complete, Behavior Revised)
 
-**Goal:** Extract metadata and classify notes - route actionable items to Things inbox
+**Status:** ✅ Complete (workflow exists) | Behavior revised 2026-01-02
 
-**🎯 KEY CHANGE:** Notes are classified by local AI, not manually reviewed. Clear tasks go directly to Things, ambiguous items are flagged for planning.
+**Original Goal:** Extract metadata and classify notes - route actionable items to Things inbox
 
-**Design Document:** See `docs/plans/2025-12-30-task-extraction-planning-design.md` for complete specification.
+**Revised Behavior:** Workflow 07 still extracts metadata and classifies, but:
+- **No longer auto-routes to Things**
+- Classification becomes a **UI hint** for SeleneChat Inbox
+- Suggests note type and related projects
+- User decides all routing through triage
 
-**Classification Categories:**
+**Design Documents:**
+- Original: `docs/plans/2025-12-30-task-extraction-planning-design.md`
+- **Revised:** `docs/plans/2026-01-02-planning-inbox-redesign.md`
 
-| Classification | Description | Routing | Example |
-|----------------|-------------|---------|---------|
-| `actionable` | Clear, specific task | Things inbox | "Call dentist tomorrow" |
-| `needs_planning` | Goal, project idea, ambiguous | Flag for SeleneChat | "Want to redo my website" |
-| `archive_only` | Thought, reflection, no action | Obsidian only | "Thinking about how attention works" |
+**Classification Categories (now UI hints):**
+
+| Classification | UI Badge | Suggested Actions | Example |
+|----------------|----------|-------------------|---------|
+| `actionable` | 📋 Quick task | Create Task, Park | "Call dentist tomorrow" |
+| `needs_planning` | 🆕 New project | Start Project, Park | "Want to redo my website" |
+| `archive_only` | 💭 Reflection | Keep in Knowledge, Archive | "Thinking about how attention works" |
+| (concept match) | 🔗 Relates to... | Add to Project, New Project | (any note matching existing project) |
 
 **Database Changes:**
 
@@ -263,41 +295,54 @@ No push notifications. No scheduled reminders. Available when you engage.
 
 ---
 
-### Phase 7.2: SeleneChat Planning Integration (Weeks 3-4)
+### Phase 7.2: SeleneChat Planning Integration (Design Revised 2026-01-02)
 
-**Status:** 📋 DESIGN COMPLETE
-**Design Doc:** [Phase 7.2 Design](../plans/2025-12-31-phase-7.2-selenechat-planning-design.md)
+**Status:** 📋 DESIGN REVISED
+**Design Docs:**
+- **Current:** [Planning Inbox Redesign](../plans/2026-01-02-planning-inbox-redesign.md)
+- **Previous:** [Phase 7.2 Design](../plans/2025-12-31-phase-7.2-selenechat-planning-design.md)
 
-**Goal:** SeleneChat queries flagged items and facilitates planning conversations
+**Goal:** SeleneChat becomes the central hub for ALL note triage and planning
 
-**Key Design Decisions (2025-12-31):**
-- **Dual AI routing:** Ollama for sensitive notes, Claude API for planning conversations
-- **Things as task database:** No task duplication - only store relationship links in Selene
-- **Methodology layer:** Editable prompts/triggers in `prompts/planning/` directory
-- **Bidirectional Things flow:** Resurface triggers (progress/stuck/complete)
-- **Single app experience:** All planning in SeleneChat, no context switching
+**Key Design Decisions (2026-01-02):**
+- **All notes to Inbox:** No auto-routing - everything parks in SeleneChat for user triage
+- **Active/Parked structure:** Prevents overwhelm (3-5 active projects max)
+- **Buttons-first triage:** Quick actions, conversation only when needed
+- **Context memory:** Projects preserve history when reopened with new notes
+- **User confirms all tasks:** Nothing goes to Things without user approval
 
-**Scope:**
-- SeleneChat queries `needs_planning` items from database
-- New "Planning" sidebar tab with thread list
-- Guided breakdown conversations using Claude API
-- Automatic task extraction → Things via URL scheme
+**Scope (Revised):**
+- **Inbox section:** All new notes with suggested types and actions
+- **Active projects:** Currently working on (limited to 3-5)
+- **Parked projects:** Everything else - not deleted, just not in focus
+- **Quick task flow:** Confirm text → Things (no full conversation needed)
+- **Planning conversations:** For complex projects, guided breakdown
 
-**SeleneChat Features:**
+**Planning Tab Structure:**
 
-1. **Planning Queries**
-   - "What needs planning?" → Shows all `needs_planning` items
-   - "Show me threads to continue" → Shows `discussion_threads` with status='pending'
+```
+┌─────────────────────────────────────────────────────────┐
+│  Planning                                        ⚙️     │
+├─────────────────────────────────────────────────────────┤
+│  📥 Inbox (4)                                           │
+│  [New notes with triage buttons]                        │
+│                                                         │
+│  🔥 Active (2)                                          │
+│  [Projects you're currently working on]                 │
+│                                                         │
+│  🅿️ Parked (12)                              [View →]   │
+│  [Everything else]                                      │
+└─────────────────────────────────────────────────────────┘
+```
 
-2. **Planning Conversations**
-   - User selects a `needs_planning` item
-   - SeleneChat facilitates breakdown using local AI
-   - Questions like: "What's the first concrete step?"
-   - Generates actionable tasks that route to Things
+**Triage Actions:**
 
-3. **Thread Continuation**
-   - `planning_prompt` from classification surfaces as conversation starters
-   - "You had an idea about [topic]. Want to plan this out?"
+| Note Type | Primary Actions |
+|-----------|-----------------|
+| 📋 Quick task | Create Task (confirm text), Park, Archive |
+| 🔗 Relates to project | Add to Project, New Project, Park |
+| 🆕 New project idea | Start Project (→ conversation), Park |
+| 💭 Reflection | Keep in Knowledge, Link to..., Archive |
 
 **Database Queries:**
 
@@ -652,10 +697,10 @@ Local re-applies: Specifics from original note
 
 ## Related Documentation
 
-- [Task Extraction Planning Design](../plans/2025-12-30-task-extraction-planning-design.md) - Complete Phase 7.1 design (2025-12-30)
-- [SeleneChat Planning Integration Design](../plans/2025-12-31-phase-7.2-selenechat-planning-design.md) - Complete Phase 7.2 design (2025-12-31)
+- **[Planning Inbox Redesign](../plans/2026-01-02-planning-inbox-redesign.md)** - Current design (2026-01-02)
+- [Task Extraction Planning Design](../plans/2025-12-30-task-extraction-planning-design.md) - Original Phase 7.1 design (superseded for routing)
+- [SeleneChat Planning Integration Design](../plans/2025-12-31-phase-7.2-selenechat-planning-design.md) - Original Phase 7.2 design (being revised)
 - [Metadata Definitions](../architecture/metadata-definitions.md) - Field specifications for classification
-- [AI Metadata Context](.claude/METADATA.md) - AI context for metadata handling
 - [Things Integration Architecture](../architecture/things-integration.md) - Technical architecture
 - [User Stories](../user-stories/things-integration-stories.md) - User scenarios and acceptance criteria
 - [ADHD Features Integration](../planning/adhd-features-integration.md) - Deep dive into ADHD principles
@@ -668,36 +713,59 @@ Local re-applies: Specifics from original note
 
 **Design Decisions:**
 
-1. **Things as Source of Truth:**
+1. **User-Controlled Triage (NEW 2026-01-02):**
+   - All notes park in SeleneChat Inbox
+   - User confirms before any task is created
+   - Prevents inbox overwhelm and AI misinterpretation
+   - Classification is a hint, not a routing decision
+
+2. **Things as Source of Truth:**
    - Prevents data duplication
    - Leverages Things' mature task management
    - Selene focuses on intelligence, not task storage
 
-2. **MCP over URL Schemes:**
-   - Bi-directional communication
-   - Richer API access
-   - More secure (AppleScript vs. URL parsing)
-
-3. **Event-Driven Workflows:**
-   - Reduces latency (no 30-second polling)
-   - Lower resource usage
-   - Immediate task creation after note processing
+3. **Active/Parked Project Structure (NEW 2026-01-02):**
+   - Limits active projects to 3-5 to force focus
+   - Parked items not forgotten, just not in face
+   - Context preserved when reopening parked projects
 
 4. **Metadata-Only Storage:**
    - Minimal database footprint
    - Respects Things as manager
    - Enrichment lives in Selene, state in Things
 
-**Open Questions:**
+**Open Questions (Updated):**
 
-- [ ] Should project creation require user approval initially?
+- [x] Should project creation require user approval initially? → YES, all user-initiated
 - [ ] What overwhelm_factor threshold triggers intervention?
 - [ ] How to handle recurring tasks in pattern analysis?
 - [ ] Should SeleneChat sync tasks real-time or cached?
 
 ---
 
-**Phase Status:** 🚧 Phase 7.1 Complete | Phase 7.2 Design Complete
-**Next Action:** Begin Phase 7.2 implementation (SeleneChat Planning Integration)
+## Future Features (Identified 2026-01-02)
+
+These features were identified during the planning inbox redesign brainstorming but are NOT part of initial implementation:
+
+### Parking Lot Rot Detection
+Surface parked items that haven't been touched in X days. "Still relevant?"
+
+### AI Suggestions When Active Doesn't Appeal
+"Nothing clicking today? Based on your energy, try 'Home Office Setup' - mostly low-energy research."
+
+### Task Check-in Conversations
+"You created 'Call dentist' 5 days ago but haven't done it. What's getting in the way?"
+Helps identify emotional blockers and reframe tasks.
+
+### Explicit Project Suggestion Correction
+"Not this" button when AI suggests wrong project match.
+
+### Auto-Park Suggestions
+"You haven't touched this active project in 2 weeks - park it?"
+
+---
+
+**Phase Status:** 🚧 Phase 7.1 Complete | Phase 7.2 Design Revised
+**Next Action:** Implement revised Phase 7.2 (Inbox + Active/Parked structure)
 **Owner:** Chase Easterling
-**Last Updated:** 2025-12-31
+**Last Updated:** 2026-01-02

--- a/test-planning-inbox-migration.sh
+++ b/test-planning-inbox-migration.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+DB_FILE=$(mktemp) || exit 1
+
+cleanup() {
+  [[ -f "$DB_FILE" ]] && rm -f "$DB_FILE"
+}
+trap cleanup EXIT INT TERM
+
+# Apply migrations
+sqlite3 "$DB_FILE" < database/schema.sql
+sqlite3 "$DB_FILE" < database/migrations/011_planning_inbox.sql
+
+# Verify tables exist
+echo "Checking projects table..."
+sqlite3 "$DB_FILE" "SELECT sql FROM sqlite_master WHERE name='projects';" | grep -q . || { echo "ERROR: projects table not found"; exit 1; }
+
+echo "Checking project_notes table..."
+sqlite3 "$DB_FILE" "SELECT sql FROM sqlite_master WHERE name='project_notes';" | grep -q . || { echo "ERROR: project_notes table not found"; exit 1; }
+
+echo "Checking raw_notes columns..."
+sqlite3 "$DB_FILE" "PRAGMA table_info(raw_notes);" | grep -qE "(inbox_status|suggested_type|suggested_project_id)" || { echo "ERROR: Expected columns not found"; exit 1; }
+
+echo "Migration test passed!"


### PR DESCRIPTION
## Summary

Redesigns Phase 7 planning flow so ALL notes go through SeleneChat Inbox for user triage before any tasks are created:

- **Inbox Triage**: Notes appear in inbox with AI-suggested type badges (Quick Task, Relates to Project, New Project, Reflection)
- **User Confirmation**: One-tap triage actions with confirmation before creating Things tasks
- **Active/Parked Projects**: Max 5 active projects to prevent overwhelm (ADHD-optimized)
- **Database Schema**: New `projects` table, `project_notes` junction, inbox columns on `raw_notes`

### Key Changes
- No auto-routing to Things (user confirms everything)
- Classification becomes UI hint, not routing decision
- Parked projects collapsed by default to reduce visual clutter
- Context preserved for reopening old projects with new notes

## Files Changed

| Category | Files |
|----------|-------|
| Database | `011_planning_inbox.sql`, `Migration002_PlanningInbox.swift` |
| Models | `NoteType.swift`, `Project.swift`, `InboxNote.swift` |
| Services | `InboxService.swift`, `ProjectService.swift` |
| Views | `TriageCardView`, `QuickTaskConfirmation`, `InboxView`, `ActiveProjectsList`, `ParkedProjectsList`, `ProjectDetailView` |
| Integration | `PlanningView.swift` refactored, `SeleneChatApp.swift` service config |

## Test Plan

- [x] Swift build passes
- [x] Database migration test passes (`./test-planning-inbox-migration.sh`)
- [ ] Manual testing: Inbox shows pending notes
- [ ] Manual testing: Triage actions work
- [ ] Manual testing: Active/Parked projects display correctly

## Design Doc

See `docs/plans/2026-01-02-planning-inbox-redesign.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)