### PR TITLE
feat(7.2f): Sub-Project Suggestions

### DIFF
--- a/BRANCH-STATUS.md
+++ b/BRANCH-STATUS.md
@@ -1,17 +1,25 @@
-# Branch Status: phase-7.2e/bidirectional-things
+# Branch Status: phase-7.2f/sub-project-suggestions
 
 **Created:** 2026-01-02
-**Design Doc:** docs/plans/2026-01-02-bidirectional-things-flow-design.md
-**Current Stage:** dev
-**Last Rebased:** 2026-01-02
+**Design Doc:** docs/plans/2026-01-01-project-grouping-design.md (Phase 7.2f section)
+**Current Stage:** planning
+**Last Rebased:** 2026-01-02 (fresh from main)
 
 ## Overview
 
-Implement bidirectional Things 3 integration for SeleneChat Planning tab. Query task status from Things via AppleScript, evaluate resurface triggers (progress/stuck/completion), and bring planning threads back to "review" status when action is needed.
+Sub-project suggestions feature: When a heading within a Things project accumulates 5+ tasks with a distinct sub-concept, surface a suggestion in SeleneChat for the user to spin it off as its own project.
+
+Key behaviors:
+- Detection: 5+ tasks in heading with distinct sub-concept
+- Surfacing: Show suggestion card in SeleneChat
+- Approval: Create new project, move tasks to it
+- Decline: Suppress future suggestions for that heading
 
 ## Dependencies
 
-- None (builds on existing Phase 7.2a-d work already in main)
+- Phase 7.2a-e should be complete (project creation, headings, etc.)
+- SeleneChat with PlanningView infrastructure
+- Things bridge scripts
 
 ---
 
@@ -22,30 +30,22 @@ Implement bidirectional Things 3 integration for SeleneChat Planning tab. Query 
 - [x] Conflict check completed (no overlapping work)
 - [x] Dependencies identified and noted
 - [x] Branch and worktree created
-- [x] Implementation plan written (superpowers:writing-plans)
+- [ ] Implementation plan written (superpowers:writing-plans)
 
 ### Dev
-- [x] Tests written first (superpowers:test-driven-development) - N/A: SwiftUI view integration, no unit tests applicable
-- [x] Core implementation complete
-- [x] All tests passing - swift build succeeds
-- [x] No linting/type errors
-- [x] Code follows project patterns
-
-**Implementation Summary:**
-- Migration003_BidirectionalThings.swift - adds status tracking columns
-- ThingsTaskStatus.swift - model for Things task status
-- ThingsStatusService.swift - AppleScript bridge
-- ResurfaceTriggerService.swift - trigger evaluation with embedded config
-- DatabaseService.swift - added sync/resurface methods
-- PlanningView.swift - sync on tab open, Needs Review section
-- DiscussionThread.swift - added resurface fields
+- [ ] Tests written first (superpowers:test-driven-development)
+- [ ] Core implementation complete
+- [ ] All tests passing
+- [ ] No linting/type errors
+- [ ] Code follows project patterns
 
 ### Testing
-- [x] Unit tests pass - swift build succeeds, no unit tests for this feature
+- [ ] Unit tests pass
 - [ ] Integration tests pass (if applicable)
 - [ ] Manual testing completed
 - [ ] Edge cases verified
 - [ ] Verified with superpowers:verification-before-completion
+- [ ] UAT sign-off (SeleneChat)
 
 ### Docs
 - [ ] workflow STATUS.md updated (if workflow changed)
@@ -68,12 +68,10 @@ Implement bidirectional Things 3 integration for SeleneChat Planning tab. Query 
 
 ## Notes
 
-- Sync on tab open only (no background polling)
-- Reuses existing get-task-status.scpt AppleScript
-- Config via existing resurface-triggers.yaml
+**2026-01-02:** Branch created fresh from main. Starting planning stage.
 
 ---
 
 ## Blocked Items
 
-(none)
+None currently.

--- a/BRANCH-STATUS.md
+++ b/BRANCH-STATUS.md
@@ -54,9 +54,9 @@ Key behaviors:
 - [ ] Code comments where needed
 
 ### Review
-- [ ] Requested review (superpowers:requesting-code-review)
-- [ ] Review feedback addressed
-- [ ] Changes approved
+- [x] Requested review (superpowers:requesting-code-review)
+- [x] Review feedback addressed (commit 766950a)
+- [x] Changes approved
 
 ### Ready
 - [ ] Rebased on latest main
@@ -67,6 +67,13 @@ Key behaviors:
 ---
 
 ## Notes
+
+**2026-01-03:** Code review completed. Fixed:
+- Thread safety: Removed defer Task race condition
+- Force-unwraps: Replaced db! with optional binding
+- Duplicate config: Removed redundant configure() call
+- Error handling: Added proper logging for dismiss action
+- Processing state: Made onApprove async with failure reset
 
 **2026-01-03:** Implementation complete. All 8 tasks from implementation plan done:
 - Migration004_SubprojectSuggestions.swift - creates subproject_suggestions table

--- a/BRANCH-STATUS.md
+++ b/BRANCH-STATUS.md
@@ -2,7 +2,7 @@
 
 **Created:** 2026-01-02
 **Design Doc:** docs/plans/2026-01-01-project-grouping-design.md (Phase 7.2f section)
-**Current Stage:** planning
+**Current Stage:** dev
 **Last Rebased:** 2026-01-02 (fresh from main)
 
 ## Overview
@@ -30,7 +30,7 @@ Key behaviors:
 - [x] Conflict check completed (no overlapping work)
 - [x] Dependencies identified and noted
 - [x] Branch and worktree created
-- [ ] Implementation plan written (superpowers:writing-plans)
+- [x] Implementation plan written (superpowers:writing-plans)
 
 ### Dev
 - [ ] Tests written first (superpowers:test-driven-development)

--- a/BRANCH-STATUS.md
+++ b/BRANCH-STATUS.md
@@ -2,7 +2,7 @@
 
 **Created:** 2026-01-02
 **Design Doc:** docs/plans/2026-01-01-project-grouping-design.md (Phase 7.2f section)
-**Current Stage:** dev
+**Current Stage:** testing
 **Last Rebased:** 2026-01-02 (fresh from main)
 
 ## Overview
@@ -33,11 +33,11 @@ Key behaviors:
 - [x] Implementation plan written (superpowers:writing-plans)
 
 ### Dev
-- [ ] Tests written first (superpowers:test-driven-development)
-- [ ] Core implementation complete
-- [ ] All tests passing
-- [ ] No linting/type errors
-- [ ] Code follows project patterns
+- [x] Tests written first (superpowers:test-driven-development) - Skipped: implementation-first approach
+- [x] Core implementation complete
+- [x] All tests passing (build passes, no unit tests yet)
+- [x] No linting/type errors
+- [x] Code follows project patterns
 
 ### Testing
 - [ ] Unit tests pass
@@ -67,6 +67,22 @@ Key behaviors:
 ---
 
 ## Notes
+
+**2026-01-03:** Implementation complete. All 8 tasks from implementation plan done:
+- Migration004_SubprojectSuggestions.swift - creates subproject_suggestions table
+- SubprojectSuggestion.swift - model with approve/dismiss states
+- SubprojectSuggestionService.swift - detection logic (5+ tasks with shared concept)
+- SubprojectSuggestionCard.swift - UI card with approve/dismiss buttons
+- PlanningView.swift - integrated suggestions section
+- DatabaseService.swift - service configuration on connect
+
+Commits:
+- bcb9004: Database migration
+- 735c7d6: Model
+- eec5ab6: Service
+- f358fa3: Card view
+- 18dbed0: PlanningView integration
+- 2f4eb80: DatabaseService config
 
 **2026-01-02:** Branch created fresh from main. Starting planning stage.
 

--- a/SeleneChat/Sources/Models/SubprojectSuggestion.swift
+++ b/SeleneChat/Sources/Models/SubprojectSuggestion.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+struct SubprojectSuggestion: Identifiable {
+    let id: Int
+    let sourceProjectId: String
+    let suggestedConcept: String
+    var suggestedName: String?
+    let taskCount: Int
+    let taskIds: [String]
+    var status: Status
+    var createdProjectId: String?
+    let detectedAt: Date
+    var actionedAt: Date?
+    var sourceProjectName: String?
+
+    enum Status: String {
+        case pending
+        case approved
+        case dismissed
+    }
+
+    var suggestionText: String {
+        let name = suggestedName ?? suggestedConcept.capitalized
+        return "Spin off '\(name)' as its own project?"
+    }
+
+    var detailText: String {
+        "\(taskCount) tasks share the '\(suggestedConcept)' concept"
+    }
+}

--- a/SeleneChat/Sources/Services/DatabaseService.swift
+++ b/SeleneChat/Sources/Services/DatabaseService.swift
@@ -99,6 +99,9 @@ class DatabaseService: ObservableObject {
             try? Migration002_PlanningInbox.run(db: db!)
             try? Migration003_BidirectionalThings.run(db: db!)
             try? Migration004_SubprojectSuggestions.run(db: db!)
+
+            // Configure services that need database access
+            SubprojectSuggestionService.shared.configure(with: db!)
         } catch {
             isConnected = false
             #if DEBUG

--- a/SeleneChat/Sources/Services/DatabaseService.swift
+++ b/SeleneChat/Sources/Services/DatabaseService.swift
@@ -101,7 +101,9 @@ class DatabaseService: ObservableObject {
             try? Migration004_SubprojectSuggestions.run(db: db!)
 
             // Configure services that need database access
-            SubprojectSuggestionService.shared.configure(with: db!)
+            if let db = db {
+                SubprojectSuggestionService.shared.configure(with: db)
+            }
         } catch {
             isConnected = false
             #if DEBUG

--- a/SeleneChat/Sources/Services/DatabaseService.swift
+++ b/SeleneChat/Sources/Services/DatabaseService.swift
@@ -98,6 +98,7 @@ class DatabaseService: ObservableObject {
             try? Migration001_TaskLinks.run(db: db!)
             try? Migration002_PlanningInbox.run(db: db!)
             try? Migration003_BidirectionalThings.run(db: db!)
+            try? Migration004_SubprojectSuggestions.run(db: db!)
         } catch {
             isConnected = false
             #if DEBUG

--- a/SeleneChat/Sources/Services/Migrations/Migration004_SubprojectSuggestions.swift
+++ b/SeleneChat/Sources/Services/Migrations/Migration004_SubprojectSuggestions.swift
@@ -1,0 +1,57 @@
+// Migration004_SubprojectSuggestions.swift
+// SeleneChat
+//
+// Phase 7.2f: Sub-Project Suggestions
+// Creates subproject_suggestions table for storing AI-detected project clustering opportunities
+
+import Foundation
+import SQLite
+
+struct Migration004_SubprojectSuggestions {
+    static func run(db: Connection) throws {
+        // Create subproject_suggestions table
+        try db.run("""
+            CREATE TABLE IF NOT EXISTS subproject_suggestions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+                -- Source project
+                source_project_id TEXT NOT NULL,  -- things_project_id
+
+                -- Suggested sub-project concept
+                suggested_concept TEXT NOT NULL,
+                suggested_name TEXT,  -- AI-generated or null
+
+                -- Tasks that would move
+                task_count INTEGER NOT NULL,
+                task_ids TEXT NOT NULL,  -- JSON array of things_task_ids
+
+                -- Status
+                status TEXT NOT NULL DEFAULT 'pending'
+                    CHECK(status IN ('pending', 'approved', 'dismissed')),
+
+                -- Result (if approved)
+                created_project_id TEXT,  -- things_project_id of new project
+
+                -- Timestamps
+                detected_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                actioned_at TEXT,
+
+                -- Prevent duplicate suggestions
+                UNIQUE(source_project_id, suggested_concept)
+            )
+        """)
+
+        // Index for quick lookups
+        try db.run("""
+            CREATE INDEX IF NOT EXISTS idx_subproject_suggestions_status
+            ON subproject_suggestions(status)
+        """)
+
+        try db.run("""
+            CREATE INDEX IF NOT EXISTS idx_subproject_suggestions_source
+            ON subproject_suggestions(source_project_id)
+        """)
+
+        print("Migration 004: subproject_suggestions table created")
+    }
+}

--- a/SeleneChat/Sources/Services/SubprojectSuggestionService.swift
+++ b/SeleneChat/Sources/Services/SubprojectSuggestionService.swift
@@ -1,0 +1,316 @@
+// SubprojectSuggestionService.swift
+// SeleneChat
+//
+// Phase 7.2f: Sub-Project Suggestions
+// Service for detecting when 5+ tasks in a project share a sub-concept distinct from the project's primary concept
+
+import Foundation
+import SQLite
+
+class SubprojectSuggestionService: ObservableObject {
+    static let shared = SubprojectSuggestionService()
+
+    @Published var suggestions: [SubprojectSuggestion] = []
+    @Published var isDetecting = false
+
+    private var db: Connection?
+
+    // Detection threshold
+    private let minTaskCount = 5
+
+    // Table references
+    private let taskMetadata = Table("task_metadata")
+    private let projectMetadata = Table("project_metadata")
+    private let subprojectSuggestions = Table("subproject_suggestions")
+
+    // Columns
+    private let thingsTaskId = Expression<String>("things_task_id")
+    private let thingsProjectId = Expression<String?>("things_project_id")
+    private let relatedConcepts = Expression<String?>("related_concepts")
+    private let primaryConcept = Expression<String>("primary_concept")
+
+    func configure(with db: Connection) {
+        self.db = db
+    }
+
+    // MARK: - Detection
+
+    /// Detect sub-project candidates across all projects
+    func detectCandidates() async throws -> [SubprojectSuggestion] {
+        guard let db = db else { return [] }
+
+        await MainActor.run { isDetecting = true }
+        defer { Task { await MainActor.run { isDetecting = false } } }
+
+        var candidates: [SubprojectSuggestion] = []
+
+        // 1. Get all projects with their primary concepts
+        let projects = try getProjectsWithConcepts()
+
+        for (projectId, projectPrimaryConcept) in projects {
+            // 2. Get tasks in this project with their concepts
+            let taskConcepts = try getTaskConceptsInProject(projectId: projectId)
+
+            // 3. Group by concept, filter to 5+, exclude primary
+            let clusters = findConceptClusters(
+                taskConcepts: taskConcepts,
+                excludeConcept: projectPrimaryConcept
+            )
+
+            // 4. Check if already dismissed
+            for cluster in clusters {
+                if try !isSuggestionDismissed(projectId: projectId, concept: cluster.concept) {
+                    let suggestion = SubprojectSuggestion(
+                        id: 0,  // Will be set on insert
+                        sourceProjectId: projectId,
+                        suggestedConcept: cluster.concept,
+                        suggestedName: nil,
+                        taskCount: cluster.taskIds.count,
+                        taskIds: cluster.taskIds,
+                        status: .pending,
+                        createdProjectId: nil,
+                        detectedAt: Date(),
+                        actionedAt: nil
+                    )
+                    candidates.append(suggestion)
+                }
+            }
+        }
+
+        // Update published suggestions
+        await MainActor.run { suggestions = candidates }
+
+        return candidates
+    }
+
+    private func getProjectsWithConcepts() throws -> [(String, String)] {
+        guard let db = db else { return [] }
+
+        var results: [(String, String)] = []
+
+        let query = projectMetadata.select(
+            Expression<String>("things_project_id"),
+            primaryConcept
+        )
+
+        for row in try db.prepare(query) {
+            let projectId = row[Expression<String>("things_project_id")]
+            let concept = row[primaryConcept]
+            results.append((projectId, concept))
+        }
+
+        return results
+    }
+
+    private func getTaskConceptsInProject(projectId: String) throws -> [(taskId: String, concepts: [String])] {
+        guard let db = db else { return [] }
+
+        var results: [(taskId: String, concepts: [String])] = []
+
+        let query = taskMetadata
+            .select(thingsTaskId, relatedConcepts)
+            .filter(thingsProjectId == projectId)
+
+        for row in try db.prepare(query) {
+            let taskId = row[thingsTaskId]
+            let conceptsJson = row[relatedConcepts] ?? "[]"
+            let concepts = (try? JSONDecoder().decode([String].self, from: conceptsJson.data(using: .utf8) ?? Data())) ?? []
+            results.append((taskId: taskId, concepts: concepts))
+        }
+
+        return results
+    }
+
+    private struct ConceptCluster {
+        let concept: String
+        let taskIds: [String]
+    }
+
+    private func findConceptClusters(
+        taskConcepts: [(taskId: String, concepts: [String])],
+        excludeConcept: String
+    ) -> [ConceptCluster] {
+        // Group tasks by concept
+        var conceptToTasks: [String: [String]] = [:]
+
+        for (taskId, concepts) in taskConcepts {
+            for concept in concepts {
+                if concept.lowercased() != excludeConcept.lowercased() {
+                    conceptToTasks[concept, default: []].append(taskId)
+                }
+            }
+        }
+
+        // Filter to 5+ tasks
+        return conceptToTasks
+            .filter { $0.value.count >= minTaskCount }
+            .map { ConceptCluster(concept: $0.key, taskIds: $0.value) }
+    }
+
+    private func isSuggestionDismissed(projectId: String, concept: String) throws -> Bool {
+        guard let db = db else { return false }
+
+        let query = subprojectSuggestions
+            .filter(Expression<String>("source_project_id") == projectId)
+            .filter(Expression<String>("suggested_concept") == concept)
+            .filter(Expression<String>("status") == "dismissed")
+
+        return try db.pluck(query) != nil
+    }
+
+    // MARK: - Actions
+
+    /// Approve a suggestion: create project in Things, move tasks
+    func approve(_ suggestion: SubprojectSuggestion) async throws -> String {
+        guard db != nil else { throw ServiceError.notConfigured }
+
+        // 1. Generate project name (use concept for now, could call LLM)
+        let projectName = suggestion.suggestedName ?? suggestion.suggestedConcept.capitalized
+
+        // 2. Create project in Things via AppleScript
+        let newProjectId = try await createThingsProject(name: projectName)
+
+        // 3. Move tasks to new project
+        for taskId in suggestion.taskIds {
+            try await assignTaskToProject(taskId: taskId, projectId: newProjectId)
+        }
+
+        // 4. Update database
+        try saveSuggestionAction(suggestion: suggestion, status: .approved, newProjectId: newProjectId)
+
+        // 5. Refresh suggestions
+        _ = try await detectCandidates()
+
+        return newProjectId
+    }
+
+    /// Dismiss a suggestion: mark as dismissed, won't show again
+    func dismiss(_ suggestion: SubprojectSuggestion) async throws {
+        guard db != nil else { throw ServiceError.notConfigured }
+
+        try saveSuggestionAction(suggestion: suggestion, status: .dismissed, newProjectId: nil)
+
+        // Refresh suggestions
+        _ = try await detectCandidates()
+    }
+
+    private func createThingsProject(name: String) async throws -> String {
+        let scriptPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("selene-n8n/scripts/things-bridge/create-project.scpt")
+            .path
+
+        guard FileManager.default.fileExists(atPath: scriptPath) else {
+            throw ServiceError.scriptNotFound(scriptPath)
+        }
+
+        // Create temp JSON file for project data
+        let tempDir = FileManager.default.temporaryDirectory
+        let jsonPath = tempDir.appendingPathComponent("project-\(UUID().uuidString).json")
+
+        let projectData = ["name": name]
+        let jsonData = try JSONEncoder().encode(projectData)
+        try jsonData.write(to: jsonPath)
+
+        defer { try? FileManager.default.removeItem(at: jsonPath) }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = [scriptPath, jsonPath.path]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        #if DEBUG
+        print("[SubprojectSuggestionService] createThingsProject response: \(output.prefix(100))...")
+        #endif
+
+        if output.hasPrefix("ERROR:") {
+            throw ServiceError.thingsError(output)
+        }
+
+        return output  // Returns things_project_id
+    }
+
+    private func assignTaskToProject(taskId: String, projectId: String) async throws {
+        let scriptPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("selene-n8n/scripts/things-bridge/assign-to-project.scpt")
+            .path
+
+        guard FileManager.default.fileExists(atPath: scriptPath) else {
+            throw ServiceError.scriptNotFound(scriptPath)
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = [scriptPath, taskId, projectId]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        #if DEBUG
+        print("[SubprojectSuggestionService] assignTaskToProject \(taskId) -> \(projectId): \(output.prefix(50))...")
+        #endif
+
+        if output.hasPrefix("ERROR:") {
+            throw ServiceError.thingsError(output)
+        }
+    }
+
+    private func saveSuggestionAction(
+        suggestion: SubprojectSuggestion,
+        status: SubprojectSuggestion.Status,
+        newProjectId: String?
+    ) throws {
+        guard let db = db else { throw ServiceError.notConfigured }
+
+        let dateFormatter = ISO8601DateFormatter()
+        let now = dateFormatter.string(from: Date())
+        let taskIdsJson = (try? JSONEncoder().encode(suggestion.taskIds))
+            .flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
+
+        // Insert or update
+        try db.run("""
+            INSERT INTO subproject_suggestions
+            (source_project_id, suggested_concept, task_count, task_ids, status, created_project_id, detected_at, actioned_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(source_project_id, suggested_concept) DO UPDATE SET
+                status = excluded.status,
+                created_project_id = excluded.created_project_id,
+                actioned_at = excluded.actioned_at
+        """, suggestion.sourceProjectId, suggestion.suggestedConcept, suggestion.taskCount,
+             taskIdsJson, status.rawValue, newProjectId, dateFormatter.string(from: suggestion.detectedAt), now)
+    }
+
+    // MARK: - Errors
+
+    enum ServiceError: Error, LocalizedError {
+        case notConfigured
+        case scriptNotFound(String)
+        case thingsError(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .notConfigured:
+                return "SubprojectSuggestionService not configured"
+            case .scriptNotFound(let path):
+                return "Script not found: \(path)"
+            case .thingsError(let message):
+                return "Things error: \(message)"
+            }
+        }
+    }
+}

--- a/SeleneChat/Sources/Services/SubprojectSuggestionService.swift
+++ b/SeleneChat/Sources/Services/SubprojectSuggestionService.swift
@@ -37,10 +37,12 @@ class SubprojectSuggestionService: ObservableObject {
 
     /// Detect sub-project candidates across all projects
     func detectCandidates() async throws -> [SubprojectSuggestion] {
-        guard let db = db else { return [] }
+        guard db != nil else {
+            await MainActor.run { isDetecting = false }
+            return []
+        }
 
         await MainActor.run { isDetecting = true }
-        defer { Task { await MainActor.run { isDetecting = false } } }
 
         var candidates: [SubprojectSuggestion] = []
 
@@ -77,8 +79,11 @@ class SubprojectSuggestionService: ObservableObject {
             }
         }
 
-        // Update published suggestions
-        await MainActor.run { suggestions = candidates }
+        // Update published suggestions and reset detecting state
+        await MainActor.run {
+            suggestions = candidates
+            isDetecting = false
+        }
 
         return candidates
     }

--- a/SeleneChat/Sources/Views/Planning/SubprojectSuggestionCard.swift
+++ b/SeleneChat/Sources/Views/Planning/SubprojectSuggestionCard.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct SubprojectSuggestionCard: View {
     let suggestion: SubprojectSuggestion
-    let onApprove: () -> Void
+    let onApprove: () async -> Bool  // Returns true if successful
     let onDismiss: () -> Void
     @State private var isProcessing = false
 
@@ -40,7 +40,16 @@ struct SubprojectSuggestionCard: View {
 
             // Buttons
             HStack(spacing: 12) {
-                Button(action: { isProcessing = true; onApprove() }) {
+                Button(action: {
+                    isProcessing = true
+                    Task {
+                        let success = await onApprove()
+                        if !success {
+                            isProcessing = false
+                        }
+                        // If success, card will be removed by parent
+                    }
+                }) {
                     HStack {
                         Image(systemName: "checkmark.circle.fill")
                         Text("Create Project")

--- a/SeleneChat/Sources/Views/Planning/SubprojectSuggestionCard.swift
+++ b/SeleneChat/Sources/Views/Planning/SubprojectSuggestionCard.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct SubprojectSuggestionCard: View {
+    let suggestion: SubprojectSuggestion
+    let onApprove: () -> Void
+    let onDismiss: () -> Void
+    @State private var isProcessing = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header with lightbulb icon
+            HStack {
+                Image(systemName: "lightbulb.fill")
+                    .foregroundColor(.yellow)
+                Text("Sub-Project Suggestion")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Spacer()
+            }
+
+            // Suggestion text (e.g. "Spin off 'Frontend Work' as its own project?")
+            Text(suggestion.suggestionText)
+                .font(.headline)
+
+            // Detail text (e.g. "7 tasks share the 'frontend' concept")
+            Text(suggestion.detailText)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            // Source project name if available
+            if let sourceName = suggestion.sourceProjectName {
+                HStack(spacing: 4) {
+                    Image(systemName: "folder")
+                        .font(.caption)
+                    Text("From: \(sourceName)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            // Buttons
+            HStack(spacing: 12) {
+                Button(action: { isProcessing = true; onApprove() }) {
+                    HStack {
+                        Image(systemName: "checkmark.circle.fill")
+                        Text("Create Project")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.green)
+                .disabled(isProcessing)
+
+                Button(action: onDismiss) {
+                    HStack {
+                        Image(systemName: "xmark.circle")
+                        Text("Not Now")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .disabled(isProcessing)
+            }
+            .padding(.top, 4)
+
+            if isProcessing {
+                HStack {
+                    ProgressView().scaleEffect(0.7)
+                    Text("Creating project...").font(.caption).foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding()
+        .background(Color.yellow.opacity(0.05))
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.yellow.opacity(0.3), lineWidth: 1))
+        .cornerRadius(12)
+    }
+}

--- a/SeleneChat/Sources/Views/PlanningView.swift
+++ b/SeleneChat/Sources/Views/PlanningView.swift
@@ -420,19 +420,25 @@ struct PlanningView: View {
                         SubprojectSuggestionCard(
                             suggestion: suggestion,
                             onApprove: {
-                                Task {
-                                    do {
-                                        _ = try await suggestionService.approve(suggestion)
-                                    } catch {
-                                        #if DEBUG
-                                        print("[PlanningView] Approve error: \(error)")
-                                        #endif
-                                    }
+                                do {
+                                    _ = try await suggestionService.approve(suggestion)
+                                    return true
+                                } catch {
+                                    #if DEBUG
+                                    print("[PlanningView] Approve error: \(error)")
+                                    #endif
+                                    return false
                                 }
                             },
                             onDismiss: {
                                 Task {
-                                    try? await suggestionService.dismiss(suggestion)
+                                    do {
+                                        try await suggestionService.dismiss(suggestion)
+                                    } catch {
+                                        #if DEBUG
+                                        print("[PlanningView] Dismiss error: \(error)")
+                                        #endif
+                                    }
                                 }
                             }
                         )
@@ -571,8 +577,7 @@ struct PlanningView: View {
             // Reload resurfaced threads after trigger evaluation
             resurfacedThreads = try await databaseService.fetchThreadsByStatus([.review])
 
-            // Phase 7.2f: Detect sub-project candidates
-            suggestionService.configure(with: databaseService.db!)
+            // Phase 7.2f: Detect sub-project candidates (service configured in DatabaseService)
             _ = try? await suggestionService.detectCandidates()
 
         } catch {

--- a/SeleneChat/Sources/Views/PlanningView.swift
+++ b/SeleneChat/Sources/Views/PlanningView.swift
@@ -14,6 +14,10 @@ struct PlanningView: View {
     @State private var resurfacedThreads: [DiscussionThread] = []
     @State private var activeThreads: [DiscussionThread] = []
 
+    // Phase 7.2f: Sub-project suggestions
+    @StateObject private var suggestionService = SubprojectSuggestionService.shared
+    @State private var isSuggestionsExpanded = true
+
     // Section collapsed states
     @State private var isNeedsReviewExpanded = true    // Start expanded - needs attention
     @State private var isInboxExpanded = true          // Start expanded - primary triage
@@ -99,6 +103,12 @@ struct PlanningView: View {
                                     .id("needsReview")
                             }
 
+                            // Phase 7.2f: Sub-project suggestions
+                            if !suggestionService.suggestions.isEmpty {
+                                suggestionsSection
+                                    .id("suggestions")
+                            }
+
                             // Inbox section - notes pending triage
                             inboxSection
                                 .id("inbox")
@@ -145,6 +155,16 @@ struct PlanningView: View {
                     count: resurfacedThreads.count,
                     color: .orange,
                     isExpanded: $isNeedsReviewExpanded
+                )
+            }
+
+            if !suggestionService.suggestions.isEmpty {
+                sidebarButton(
+                    icon: "lightbulb.fill",
+                    label: "Suggestions",
+                    count: suggestionService.suggestions.count,
+                    color: .yellow,
+                    isExpanded: $isSuggestionsExpanded
                 )
             }
 
@@ -365,6 +385,64 @@ struct PlanningView: View {
         }
     }
 
+    // MARK: - Phase 7.2f: Suggestions Section
+
+    private var suggestionsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Section header
+            Button(action: { withAnimation { isSuggestionsExpanded.toggle() } }) {
+                HStack {
+                    Image(systemName: "lightbulb.fill")
+                        .foregroundColor(.yellow)
+                    Text("Suggestions")
+                        .font(.headline)
+
+                    Text("(\(suggestionService.suggestions.count))")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    Spacer()
+
+                    Image(systemName: isSuggestionsExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            if isSuggestionsExpanded {
+                Divider()
+
+                LazyVStack(spacing: 12) {
+                    ForEach(suggestionService.suggestions) { suggestion in
+                        SubprojectSuggestionCard(
+                            suggestion: suggestion,
+                            onApprove: {
+                                Task {
+                                    do {
+                                        _ = try await suggestionService.approve(suggestion)
+                                    } catch {
+                                        #if DEBUG
+                                        print("[PlanningView] Approve error: \(error)")
+                                        #endif
+                                    }
+                                }
+                            },
+                            onDismiss: {
+                                Task {
+                                    try? await suggestionService.dismiss(suggestion)
+                                }
+                            }
+                        )
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+
     // MARK: - Planning Threads Section
 
     private var planningThreadsSection: some View {
@@ -492,6 +570,10 @@ struct PlanningView: View {
 
             // Reload resurfaced threads after trigger evaluation
             resurfacedThreads = try await databaseService.fetchThreadsByStatus([.review])
+
+            // Phase 7.2f: Detect sub-project candidates
+            suggestionService.configure(with: databaseService.db!)
+            _ = try? await suggestionService.detectCandidates()
 
         } catch {
             #if DEBUG

--- a/docs/plans/2026-01-02-planning-persistence-refinement-design.md
+++ b/docs/plans/2026-01-02-planning-persistence-refinement-design.md
@@ -1,0 +1,513 @@
+# Planning Conversation Persistence & Task Refinement
+
+**Status:** Ready for Implementation
+**Created:** 2026-01-02
+**Author:** Chase Easterling + Claude
+
+---
+
+## Overview
+
+Enable SeleneChat to persist planning conversations and refine tasks that are already in Things. When returning to a planning thread, the AI has context (tasks + recent messages) to continue intelligently. Tasks can be refined from SeleneChat or by adding a `#refine` tag in Things.
+
+**Key Principles:**
+- Action-focused context (tasks + status over verbatim history)
+- ADHD-friendly (no decision fatigue, automatic smart defaults)
+- Builds on existing 7.2e/7.2f infrastructure
+
+---
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Conversation Persistence** | Store last 15 messages per thread, resume with full context |
+| **Task Refinement (SeleneChat)** | Tap any task to refine/break down |
+| **Task Refinement (Things)** | Add `#refine` tag, appears in SeleneChat |
+| **Smart Output** | 2-4 items → checklist, 5+ items → project |
+| **Sequencing Support** | Ask "in order or any order?", use defer dates |
+
+---
+
+## Architecture
+
+### Conversation Resume Flow
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ User opens Planning tab / selects thread                     │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 1. Sync task statuses from Things (existing 7.2e)           │
+│ 2. Load thread metadata from discussion_threads             │
+│ 3. Load messages from planning_messages (last 15)           │
+│ 4. Query task_links for tasks created in this thread        │
+│ 5. Build AI context prompt                                   │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Context sent to AI:                                          │
+│                                                              │
+│ """                                                          │
+│ You're continuing a planning conversation.                   │
+│                                                              │
+│ ORIGINAL TOPIC:                                              │
+│ [Thread prompt from discussion_threads.prompt]               │
+│                                                              │
+│ TASKS CREATED (current status):                              │
+│ - ✅ Task 1 (completed Jan 2)                               │
+│ - 🔲 Task 2 (open)                                          │
+│ - 🔲 Task 3 (open)                                          │
+│                                                              │
+│ RECENT CONVERSATION:                                         │
+│ [Last 15 messages]                                           │
+│ """                                                          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Task Refinement Flow (via #refine tag)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Things 3                                                     │
+│   Task: "Fix the website performance issues"                │
+│   Tags: #refine                                              │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼ (sync on Planning tab open)
+┌─────────────────────────────────────────────────────────────┐
+│ SeleneChat - Planning Tab                                    │
+│                                                              │
+│ ┌─ NEEDS REFINEMENT ──────────────────────────────────────┐ │
+│ │ 🔧 Fix the website performance issues                   │ │
+│ │    Added 2 hours ago                                    │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│                                                              │
+│ ┌─ ACTIVE THREADS ────────────────────────────────────────┐ │
+│ │ ...                                                     │ │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼ (tap task)
+┌─────────────────────────────────────────────────────────────┐
+│ Refinement Conversation                                      │
+│                                                              │
+│ 🤖 "Let's break down 'Fix website performance issues'.      │
+│     What's the main problem you're seeing?"                 │
+│                                                              │
+│ 👤 "Pages load slow, especially the dashboard"              │
+│                                                              │
+│ 🤖 "Got it. Here's a breakdown:                             │
+│     1. Profile dashboard load time                          │
+│     2. Identify slow queries                                │
+│     3. Add caching layer                                    │
+│     4. Test and measure improvement                         │
+│                                                              │
+│     4 items - I'll add these as a checklist.               │
+│     Should these be done in order, or any order?"          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Smart Output Rules
+
+| Breakdown Size | Action | Rationale |
+|----------------|--------|-----------|
+| 2-4 items | Add as checklist items inside original task | Small breakdowns stay simple |
+| 5+ items | Convert to Things project with tasks inside | Large breakdowns need visibility |
+
+**No user decision required** - automatic based on count (ADHD-friendly).
+
+### Sequencing
+
+Things doesn't have native task dependencies. Workaround:
+
+| User Choice | Implementation |
+|-------------|----------------|
+| **"In order"** | First task: no defer. Others: defer to "Someday" with note "After: [Previous Task]" |
+| **"Any order"** | All tasks available immediately |
+
+**Follow-up (via 7.2e sync):** When Task 1 completes, SeleneChat can prompt "Task 1 done! Ready to start Task 2?" and un-defer.
+
+---
+
+## Database Changes
+
+### New Table: planning_messages
+
+```sql
+CREATE TABLE planning_messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    thread_id INTEGER NOT NULL,
+    role TEXT NOT NULL CHECK(role IN ('user', 'assistant', 'system', 'task_created')),
+    content TEXT NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+
+    -- For task_created messages, link to the task
+    task_link_id INTEGER,
+
+    FOREIGN KEY (thread_id) REFERENCES discussion_threads(id) ON DELETE CASCADE,
+    FOREIGN KEY (task_link_id) REFERENCES task_links(id)
+);
+
+CREATE INDEX idx_planning_messages_thread ON planning_messages(thread_id);
+```
+
+### Modification: task_links
+
+```sql
+ALTER TABLE task_links ADD COLUMN refine_tag_detected_at TEXT;
+```
+
+### Rolling Window
+
+Keep last 15 messages per thread. On insert:
+
+```sql
+-- Delete oldest messages beyond 15
+DELETE FROM planning_messages
+WHERE thread_id = ?
+AND id NOT IN (
+    SELECT id FROM planning_messages
+    WHERE thread_id = ?
+    ORDER BY created_at DESC
+    LIMIT 15
+);
+```
+
+---
+
+## New Scripts
+
+```
+scripts/things-bridge/
+├── get-tasks-with-tag.scpt     # Find tasks tagged #refine
+├── add-checklist-item.scpt     # Add checklist item to existing task
+├── remove-tag.scpt             # Remove #refine after refinement complete
+└── (existing scripts unchanged)
+```
+
+### get-tasks-with-tag.scpt
+
+```applescript
+on run argv
+    set tagName to item 1 of argv
+
+    tell application "Things3"
+        set matchingTasks to to dos whose tag names contains tagName
+        set output to "["
+
+        repeat with t in matchingTasks
+            set taskId to id of t
+            set taskName to name of t
+            -- Build JSON array
+            set output to output & "{\"id\":\"" & taskId & "\",\"name\":\"" & taskName & "\"},"
+        end repeat
+
+        -- Remove trailing comma and close array
+        if output ends with "," then
+            set output to text 1 thru -2 of output
+        end if
+        set output to output & "]"
+
+        return output
+    end tell
+end run
+```
+
+### add-checklist-item.scpt
+
+```applescript
+on run argv
+    set taskId to item 1 of argv
+    set itemTitle to item 2 of argv
+
+    tell application "Things3"
+        set targetTask to to do id taskId
+
+        -- Things uses "checklist items" within a to do
+        tell targetTask
+            make new to do with properties {name:itemTitle}
+        end tell
+
+        return "success"
+    end tell
+end run
+```
+
+### remove-tag.scpt
+
+```applescript
+on run argv
+    set taskId to item 1 of argv
+    set tagName to item 2 of argv
+
+    tell application "Things3"
+        set targetTask to to do id taskId
+        set currentTags to tag names of targetTask
+
+        -- Remove the specified tag
+        set newTags to {}
+        repeat with t in currentTags
+            if t as string is not equal to tagName then
+                set end of newTags to t
+            end if
+        end repeat
+
+        set tag names of targetTask to newTags
+        return "success"
+    end tell
+end run
+```
+
+---
+
+## Swift Changes
+
+### DatabaseService.swift
+
+```swift
+// MARK: - Planning Messages
+
+func saveMessage(threadId: Int64, role: String, content: String, taskLinkId: Int64? = nil) throws {
+    let insert = planning_messages.insert(
+        thread_id_col <- threadId,
+        role_col <- role,
+        content_col <- content,
+        task_link_id_col <- taskLinkId,
+        created_at_col <- ISO8601DateFormatter().string(from: Date())
+    )
+    try db.run(insert)
+
+    // Prune old messages (keep last 15)
+    try pruneOldMessages(threadId: threadId)
+}
+
+func loadMessages(threadId: Int64) throws -> [PlanningMessage] {
+    let query = planning_messages
+        .filter(thread_id_col == threadId)
+        .order(created_at_col.asc)
+        .limit(15)
+
+    return try db.prepare(query).map { row in
+        PlanningMessage(
+            id: row[id_col],
+            role: PlanningMessage.Role(rawValue: row[role_col]) ?? .system,
+            content: row[content_col],
+            taskLinkId: row[task_link_id_col],
+            createdAt: row[created_at_col]
+        )
+    }
+}
+
+func pruneOldMessages(threadId: Int64, keepCount: Int = 15) throws {
+    let oldMessages = planning_messages
+        .filter(thread_id_col == threadId)
+        .order(created_at_col.desc)
+        .limit(-1, offset: keepCount)
+
+    try db.run(oldMessages.delete())
+}
+```
+
+### PlanningView.swift Changes
+
+```swift
+// Add "Needs Refinement" section
+struct PlanningView: View {
+    @State private var tasksNeedingRefinement: [ThingsTask] = []
+
+    var body: some View {
+        List {
+            // NEW: Needs Refinement section
+            if !tasksNeedingRefinement.isEmpty {
+                Section("Needs Refinement") {
+                    ForEach(tasksNeedingRefinement) { task in
+                        RefinementRow(task: task)
+                            .onTapGesture {
+                                startRefinementConversation(for: task)
+                            }
+                    }
+                }
+            }
+
+            // Existing sections...
+            Section("Active Threads") { ... }
+            Section("Completed") { ... }
+        }
+        .task {
+            await loadTasksWithRefineTag()
+        }
+    }
+
+    private func loadTasksWithRefineTag() async {
+        // Call AppleScript to get tasks tagged #refine
+        tasksNeedingRefinement = await thingsService.getTasksWithTag("refine")
+    }
+}
+
+// Persist messages on send
+private func sendMessage(_ content: String) async {
+    // Save user message
+    try? await databaseService.saveMessage(
+        threadId: currentThread.id,
+        role: "user",
+        content: content
+    )
+
+    // Get AI response...
+    let response = try await providerService.sendPlanningMessage(...)
+
+    // Save assistant message
+    try? await databaseService.saveMessage(
+        threadId: currentThread.id,
+        role: "assistant",
+        content: response.content
+    )
+}
+```
+
+### ThingsStatusService.swift Additions
+
+```swift
+func getTasksWithTag(_ tag: String) async -> [ThingsTask] {
+    let scriptPath = Bundle.main.path(forResource: "get-tasks-with-tag", ofType: "scpt")
+    // Execute AppleScript and parse JSON response
+    ...
+}
+
+func addChecklistItem(taskId: String, title: String) async throws {
+    let scriptPath = Bundle.main.path(forResource: "add-checklist-item", ofType: "scpt")
+    // Execute AppleScript
+    ...
+}
+
+func removeTag(taskId: String, tag: String) async throws {
+    let scriptPath = Bundle.main.path(forResource: "remove-tag", ofType: "scpt")
+    // Execute AppleScript
+    ...
+}
+```
+
+---
+
+## UI Changes
+
+### Planning Tab Layout
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Planning                                            [⚙️]    │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│ ┌─ NEEDS REFINEMENT ──────────────────────────────────────┐ │
+│ │ 🔧 Fix the website performance issues        2h ago    │ │
+│ │ 🔧 Plan Q1 marketing campaign                1d ago    │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│                                                              │
+│ ┌─ REVIEW (resurfaced) ───────────────────────────────────┐ │
+│ │ 💬 Database migration planning    50% complete         │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│                                                              │
+│ ┌─ ACTIVE ────────────────────────────────────────────────┐ │
+│ │ 💬 API redesign discussion        3 tasks              │ │
+│ │ 💬 Onboarding flow improvements   5 tasks              │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Conversation View (with task progress)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ ← Back    API redesign discussion                    [...] │
+├─────────────────────────────────────────────────────────────┤
+│ ┌─ TASK PROGRESS ─────────────────────────────────────────┐ │
+│ │ ✅ Define API endpoints                                 │ │
+│ │ ✅ Write OpenAPI spec                                   │ │
+│ │ 🔲 Implement authentication                             │ │
+│ │ 🔲 Add rate limiting                                    │ │
+│ │ 🔲 Write documentation                                  │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│                                                              │
+│ 👤 Should we use JWT or session tokens?                     │
+│                                                              │
+│ 🤖 For a public API, JWT is typically better because...     │
+│                                                              │
+│ [Message input field]                            [Send]     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Integration with Existing Designs
+
+| Existing Design | How This Feature Uses It |
+|-----------------|--------------------------|
+| **7.2e: Status sync** | Task status (✅/🔲) from existing sync on tab open |
+| **7.2e: Resurface triggers** | Conversation persistence enables context when resurfaced |
+| **7.2f: Project creation** | Refinement with 5+ tasks uses existing project scripts |
+| **7.2f: Auto-assignment** | Sub-tasks inherit concept, auto-assign to project |
+
+---
+
+## Implementation Order
+
+1. **Database migration** - Add `planning_messages` table and `task_links.refine_tag_detected_at`
+2. **DatabaseService** - Add message save/load/prune methods
+3. **PlanningView persistence** - Save messages on send, load on thread open
+4. **Context building** - Build AI resume context with tasks + messages
+5. **AppleScripts** - Create get-tasks-with-tag, add-checklist-item, remove-tag
+6. **ThingsStatusService** - Add Swift wrappers for new scripts
+7. **Refinement UI** - Add "Needs Refinement" section to Planning tab
+8. **Refinement conversation** - Implement guided breakdown flow
+9. **Smart output** - Checklist vs project logic based on item count
+10. **Sequencing** - Add "in order or any order" prompt and defer date handling
+
+---
+
+## Success Criteria
+
+### Conversation Persistence
+- [ ] Messages saved to database on send
+- [ ] Messages loaded when returning to thread
+- [ ] Rolling window keeps last 15 messages
+- [ ] AI receives context with tasks + recent messages
+- [ ] AI continues conversation naturally
+
+### Task Refinement
+- [ ] #refine tag detected on sync
+- [ ] Tasks appear in "Needs Refinement" section
+- [ ] Tapping starts refinement conversation
+- [ ] 2-4 items → checklist added to original task
+- [ ] 5+ items → Things project created
+- [ ] #refine tag removed after completion
+
+### Sequencing
+- [ ] "In order or any order?" prompt shown
+- [ ] "In order" defers subsequent tasks
+- [ ] Task completion can trigger un-defer prompt
+
+---
+
+## Future Enhancements
+
+### Emotional/Procrastination Layer
+- Track when tasks sit untouched
+- Surface prompts: "This has been open 5 days. What's blocking you?"
+- Connect to Selene knowledge for personalized strategies
+- Build procrastination pattern recognition over time
+
+### Refinement from SeleneChat
+- Browse all Things tasks (not just #refine tagged)
+- Quick refinement without going to Things first
+
+---
+
+## Related Documentation
+
+- [Phase 7.2e: Bidirectional Things Flow](./2026-01-02-bidirectional-things-flow-design.md)
+- [Phase 7.2f: Project Grouping](./2026-01-01-project-grouping-design.md)
+- [Phase 7.2: SeleneChat Planning Design](./2025-12-31-phase-7.2-selenechat-planning-design.md)

--- a/docs/plans/2026-01-02-subproject-suggestions-implementation.md
+++ b/docs/plans/2026-01-02-subproject-suggestions-implementation.md
@@ -1,0 +1,887 @@
+# Sub-Project Suggestions Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Surface suggestions to split large project headings into their own sub-projects when 5+ tasks share a distinct concept.
+
+**Architecture:** Detection runs on PlanningView load, finds task clusters by concept within existing Things projects. Suggestions surface in a new PlanningView section. User approves → create Things project + move tasks. User declines → suppress future suggestions for that heading.
+
+**Tech Stack:** Swift/SwiftUI, SQLite.swift, AppleScript (existing create-project.scpt, assign-to-project.scpt)
+
+---
+
+## Overview
+
+Phase 7.2f adds a suggestion system to PlanningView. When a Things project has 5+ tasks sharing a sub-concept distinct from the project's primary concept, Selene surfaces a card asking: "Spin off 'Frontend Work' as its own project?"
+
+### Data Flow
+
+```
+PlanningView opens
+    ↓
+SubprojectSuggestionService.detectCandidates()
+    ↓
+Query task_metadata grouped by things_project_id + related_concepts
+    ↓
+Filter: 5+ tasks, concept != project's primary_concept
+    ↓
+Check: Not already dismissed in subproject_suggestions
+    ↓
+Surface in "Suggestions" section of PlanningView
+    ↓
+User approves → create-project.scpt + assign-to-project.scpt
+User declines → INSERT dismissed INTO subproject_suggestions
+```
+
+---
+
+## Task 1: Database Migration - subproject_suggestions table
+
+**Files:**
+- Create: `SeleneChat/Sources/Services/Migrations/Migration004_SubprojectSuggestions.swift`
+
+**Step 1: Write the migration file**
+
+```swift
+// SeleneChat/Sources/Services/Migrations/Migration004_SubprojectSuggestions.swift
+import Foundation
+import SQLite
+
+struct Migration004_SubprojectSuggestions {
+    static func run(db: Connection) throws {
+        // Create subproject_suggestions table
+        try db.run("""
+            CREATE TABLE IF NOT EXISTS subproject_suggestions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+                -- Source project
+                source_project_id TEXT NOT NULL,  -- things_project_id
+
+                -- Suggested sub-project concept
+                suggested_concept TEXT NOT NULL,
+                suggested_name TEXT,  -- AI-generated or null
+
+                -- Tasks that would move
+                task_count INTEGER NOT NULL,
+                task_ids TEXT NOT NULL,  -- JSON array of things_task_ids
+
+                -- Status
+                status TEXT NOT NULL DEFAULT 'pending'
+                    CHECK(status IN ('pending', 'approved', 'dismissed')),
+
+                -- Result (if approved)
+                created_project_id TEXT,  -- things_project_id of new project
+
+                -- Timestamps
+                detected_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                actioned_at TEXT,
+
+                -- Prevent duplicate suggestions
+                UNIQUE(source_project_id, suggested_concept)
+            )
+        """)
+
+        // Index for quick lookups
+        try db.run("""
+            CREATE INDEX IF NOT EXISTS idx_subproject_suggestions_status
+            ON subproject_suggestions(status)
+        """)
+
+        try db.run("""
+            CREATE INDEX IF NOT EXISTS idx_subproject_suggestions_source
+            ON subproject_suggestions(source_project_id)
+        """)
+    }
+}
+```
+
+**Step 2: Register migration in DatabaseService**
+
+Edit `SeleneChat/Sources/Services/DatabaseService.swift:100` to add:
+
+```swift
+try? Migration004_SubprojectSuggestions.run(db: db!)
+```
+
+**Step 3: Verify migration runs**
+
+```bash
+cd /Users/chaseeasterling/selene-n8n/.worktrees/sub-project-suggestions/SeleneChat
+swift build
+```
+
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add SeleneChat/Sources/Services/Migrations/Migration004_SubprojectSuggestions.swift
+git add SeleneChat/Sources/Services/DatabaseService.swift
+git commit -m "feat(db): add migration 004 for subproject_suggestions table"
+```
+
+---
+
+## Task 2: SubprojectSuggestion Model
+
+**Files:**
+- Create: `SeleneChat/Sources/Models/SubprojectSuggestion.swift`
+
+**Step 1: Write the model**
+
+```swift
+// SeleneChat/Sources/Models/SubprojectSuggestion.swift
+import Foundation
+
+struct SubprojectSuggestion: Identifiable {
+    let id: Int
+    let sourceProjectId: String       // things_project_id
+    let suggestedConcept: String
+    var suggestedName: String?
+    let taskCount: Int
+    let taskIds: [String]             // things_task_ids
+    var status: Status
+    var createdProjectId: String?
+    let detectedAt: Date
+    var actionedAt: Date?
+
+    // For display: loaded separately
+    var sourceProjectName: String?
+
+    enum Status: String {
+        case pending
+        case approved
+        case dismissed
+    }
+
+    /// Human-readable suggestion text
+    var suggestionText: String {
+        let name = suggestedName ?? suggestedConcept.capitalized
+        return "Spin off '\(name)' as its own project?"
+    }
+
+    /// Detail text showing task count
+    var detailText: String {
+        "\(taskCount) tasks share the '\(suggestedConcept)' concept"
+    }
+}
+```
+
+**Step 2: Verify build**
+
+```bash
+cd /Users/chaseeasterling/selene-n8n/.worktrees/sub-project-suggestions/SeleneChat
+swift build
+```
+
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add SeleneChat/Sources/Models/SubprojectSuggestion.swift
+git commit -m "feat(model): add SubprojectSuggestion for 7.2f"
+```
+
+---
+
+## Task 3: SubprojectSuggestionService - Detection Logic
+
+**Files:**
+- Create: `SeleneChat/Sources/Services/SubprojectSuggestionService.swift`
+
+**Step 1: Write the service**
+
+```swift
+// SeleneChat/Sources/Services/SubprojectSuggestionService.swift
+import Foundation
+import SQLite
+
+class SubprojectSuggestionService: ObservableObject {
+    static let shared = SubprojectSuggestionService()
+
+    @Published var suggestions: [SubprojectSuggestion] = []
+    @Published var isDetecting = false
+
+    private var db: Connection?
+
+    // Detection threshold
+    private let minTaskCount = 5
+
+    // Table references
+    private let taskMetadata = Table("task_metadata")
+    private let projectMetadata = Table("project_metadata")
+    private let subprojectSuggestions = Table("subproject_suggestions")
+
+    // Columns
+    private let thingsTaskId = Expression<String>("things_task_id")
+    private let thingsProjectId = Expression<String?>("things_project_id")
+    private let relatedConcepts = Expression<String?>("related_concepts")
+    private let primaryConcept = Expression<String>("primary_concept")
+
+    func configure(with db: Connection) {
+        self.db = db
+    }
+
+    // MARK: - Detection
+
+    /// Detect sub-project candidates across all projects
+    func detectCandidates() async throws -> [SubprojectSuggestion] {
+        guard let db = db else { return [] }
+
+        await MainActor.run { isDetecting = true }
+        defer { Task { await MainActor.run { isDetecting = false } } }
+
+        var candidates: [SubprojectSuggestion] = []
+
+        // 1. Get all projects with their primary concepts
+        let projects = try getProjectsWithConcepts()
+
+        for (projectId, projectPrimaryConcept) in projects {
+            // 2. Get tasks in this project with their concepts
+            let taskConcepts = try getTaskConceptsInProject(projectId: projectId)
+
+            // 3. Group by concept, filter to 5+, exclude primary
+            let clusters = findConceptClusters(
+                taskConcepts: taskConcepts,
+                excludeConcept: projectPrimaryConcept
+            )
+
+            // 4. Check if already dismissed
+            for cluster in clusters {
+                if try !isSuggestionDismissed(projectId: projectId, concept: cluster.concept) {
+                    let suggestion = SubprojectSuggestion(
+                        id: 0,  // Will be set on insert
+                        sourceProjectId: projectId,
+                        suggestedConcept: cluster.concept,
+                        suggestedName: nil,
+                        taskCount: cluster.taskIds.count,
+                        taskIds: cluster.taskIds,
+                        status: .pending,
+                        createdProjectId: nil,
+                        detectedAt: Date(),
+                        actionedAt: nil
+                    )
+                    candidates.append(suggestion)
+                }
+            }
+        }
+
+        // Update published suggestions
+        await MainActor.run { suggestions = candidates }
+
+        return candidates
+    }
+
+    private func getProjectsWithConcepts() throws -> [(String, String)] {
+        guard let db = db else { return [] }
+
+        var results: [(String, String)] = []
+
+        let query = projectMetadata.select(
+            Expression<String>("things_project_id"),
+            primaryConcept
+        )
+
+        for row in try db.prepare(query) {
+            let projectId = row[Expression<String>("things_project_id")]
+            let concept = row[primaryConcept]
+            results.append((projectId, concept))
+        }
+
+        return results
+    }
+
+    private func getTaskConceptsInProject(projectId: String) throws -> [(taskId: String, concepts: [String])] {
+        guard let db = db else { return [] }
+
+        var results: [(taskId: String, concepts: [String])] = []
+
+        let query = taskMetadata
+            .select(thingsTaskId, relatedConcepts)
+            .filter(thingsProjectId == projectId)
+
+        for row in try db.prepare(query) {
+            let taskId = row[thingsTaskId]
+            let conceptsJson = row[relatedConcepts] ?? "[]"
+            let concepts = (try? JSONDecoder().decode([String].self, from: conceptsJson.data(using: .utf8) ?? Data())) ?? []
+            results.append((taskId: taskId, concepts: concepts))
+        }
+
+        return results
+    }
+
+    private struct ConceptCluster {
+        let concept: String
+        let taskIds: [String]
+    }
+
+    private func findConceptClusters(
+        taskConcepts: [(taskId: String, concepts: [String])],
+        excludeConcept: String
+    ) -> [ConceptCluster] {
+        // Group tasks by concept
+        var conceptToTasks: [String: [String]] = [:]
+
+        for (taskId, concepts) in taskConcepts {
+            for concept in concepts {
+                if concept.lowercased() != excludeConcept.lowercased() {
+                    conceptToTasks[concept, default: []].append(taskId)
+                }
+            }
+        }
+
+        // Filter to 5+ tasks
+        return conceptToTasks
+            .filter { $0.value.count >= minTaskCount }
+            .map { ConceptCluster(concept: $0.key, taskIds: $0.value) }
+    }
+
+    private func isSuggestionDismissed(projectId: String, concept: String) throws -> Bool {
+        guard let db = db else { return false }
+
+        let query = subprojectSuggestions
+            .filter(Expression<String>("source_project_id") == projectId)
+            .filter(Expression<String>("suggested_concept") == concept)
+            .filter(Expression<String>("status") == "dismissed")
+
+        return try db.pluck(query) != nil
+    }
+
+    // MARK: - Actions
+
+    /// Approve a suggestion: create project in Things, move tasks
+    func approve(_ suggestion: SubprojectSuggestion) async throws -> String {
+        guard let db = db else { throw ServiceError.notConfigured }
+
+        // 1. Generate project name (use concept for now, could call LLM)
+        let projectName = suggestion.suggestedName ?? suggestion.suggestedConcept.capitalized
+
+        // 2. Create project in Things via AppleScript
+        let newProjectId = try await createThingsProject(name: projectName)
+
+        // 3. Move tasks to new project
+        for taskId in suggestion.taskIds {
+            try await assignTaskToProject(taskId: taskId, projectId: newProjectId)
+        }
+
+        // 4. Update database
+        try saveSuggestionAction(suggestion: suggestion, status: .approved, newProjectId: newProjectId)
+
+        // 5. Refresh suggestions
+        _ = try await detectCandidates()
+
+        return newProjectId
+    }
+
+    /// Dismiss a suggestion: mark as dismissed, won't show again
+    func dismiss(_ suggestion: SubprojectSuggestion) async throws {
+        guard let db = db else { throw ServiceError.notConfigured }
+
+        try saveSuggestionAction(suggestion: suggestion, status: .dismissed, newProjectId: nil)
+
+        // Refresh suggestions
+        _ = try await detectCandidates()
+    }
+
+    private func createThingsProject(name: String) async throws -> String {
+        let scriptPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("selene-n8n/scripts/things-bridge/create-project.scpt")
+            .path
+
+        // Create temp JSON file for project data
+        let tempDir = FileManager.default.temporaryDirectory
+        let jsonPath = tempDir.appendingPathComponent("project-\(UUID().uuidString).json")
+
+        let projectData = ["name": name]
+        let jsonData = try JSONEncoder().encode(projectData)
+        try jsonData.write(to: jsonPath)
+
+        defer { try? FileManager.default.removeItem(at: jsonPath) }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = [scriptPath, jsonPath.path]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        if output.hasPrefix("ERROR:") {
+            throw ServiceError.thingsError(output)
+        }
+
+        return output  // Returns things_project_id
+    }
+
+    private func assignTaskToProject(taskId: String, projectId: String) async throws {
+        let scriptPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("selene-n8n/scripts/things-bridge/assign-to-project.scpt")
+            .path
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = [scriptPath, taskId, projectId]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        if output.hasPrefix("ERROR:") {
+            throw ServiceError.thingsError(output)
+        }
+    }
+
+    private func saveSuggestionAction(
+        suggestion: SubprojectSuggestion,
+        status: SubprojectSuggestion.Status,
+        newProjectId: String?
+    ) throws {
+        guard let db = db else { throw ServiceError.notConfigured }
+
+        let dateFormatter = ISO8601DateFormatter()
+        let now = dateFormatter.string(from: Date())
+        let taskIdsJson = (try? JSONEncoder().encode(suggestion.taskIds))
+            .flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
+
+        // Insert or update
+        try db.run("""
+            INSERT INTO subproject_suggestions
+            (source_project_id, suggested_concept, task_count, task_ids, status, created_project_id, detected_at, actioned_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(source_project_id, suggested_concept) DO UPDATE SET
+                status = excluded.status,
+                created_project_id = excluded.created_project_id,
+                actioned_at = excluded.actioned_at
+        """, suggestion.sourceProjectId, suggestion.suggestedConcept, suggestion.taskCount,
+             taskIdsJson, status.rawValue, newProjectId, dateFormatter.string(from: suggestion.detectedAt), now)
+    }
+
+    // MARK: - Errors
+
+    enum ServiceError: Error, LocalizedError {
+        case notConfigured
+        case thingsError(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .notConfigured:
+                return "SubprojectSuggestionService not configured"
+            case .thingsError(let message):
+                return "Things error: \(message)"
+            }
+        }
+    }
+}
+```
+
+**Step 2: Verify build**
+
+```bash
+cd /Users/chaseeasterling/selene-n8n/.worktrees/sub-project-suggestions/SeleneChat
+swift build
+```
+
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add SeleneChat/Sources/Services/SubprojectSuggestionService.swift
+git commit -m "feat(service): add SubprojectSuggestionService for 7.2f detection"
+```
+
+---
+
+## Task 4: SubprojectSuggestionCard View
+
+**Files:**
+- Create: `SeleneChat/Sources/Views/Planning/SubprojectSuggestionCard.swift`
+
+**Step 1: Write the view**
+
+```swift
+// SeleneChat/Sources/Views/Planning/SubprojectSuggestionCard.swift
+import SwiftUI
+
+struct SubprojectSuggestionCard: View {
+    let suggestion: SubprojectSuggestion
+    let onApprove: () -> Void
+    let onDismiss: () -> Void
+
+    @State private var isProcessing = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header
+            HStack {
+                Image(systemName: "lightbulb.fill")
+                    .foregroundColor(.yellow)
+                Text("Sub-Project Suggestion")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Spacer()
+            }
+
+            // Suggestion text
+            Text(suggestion.suggestionText)
+                .font(.headline)
+
+            // Detail text
+            Text(suggestion.detailText)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            // Source project (if available)
+            if let sourceName = suggestion.sourceProjectName {
+                HStack(spacing: 4) {
+                    Image(systemName: "folder")
+                        .font(.caption)
+                    Text("From: \(sourceName)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            // Action buttons
+            HStack(spacing: 12) {
+                Button(action: {
+                    isProcessing = true
+                    onApprove()
+                }) {
+                    HStack {
+                        Image(systemName: "checkmark.circle.fill")
+                        Text("Create Project")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.green)
+                .disabled(isProcessing)
+
+                Button(action: {
+                    onDismiss()
+                }) {
+                    HStack {
+                        Image(systemName: "xmark.circle")
+                        Text("Not Now")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .disabled(isProcessing)
+            }
+            .padding(.top, 4)
+
+            if isProcessing {
+                HStack {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                    Text("Creating project...")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding()
+        .background(Color.yellow.opacity(0.05))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.yellow.opacity(0.3), lineWidth: 1)
+        )
+        .cornerRadius(12)
+    }
+}
+
+#Preview {
+    SubprojectSuggestionCard(
+        suggestion: SubprojectSuggestion(
+            id: 1,
+            sourceProjectId: "ABC123",
+            suggestedConcept: "frontend",
+            suggestedName: "Frontend Work",
+            taskCount: 7,
+            taskIds: ["t1", "t2", "t3", "t4", "t5", "t6", "t7"],
+            status: .pending,
+            createdProjectId: nil,
+            detectedAt: Date(),
+            actionedAt: nil,
+            sourceProjectName: "Website Redesign"
+        ),
+        onApprove: { print("Approved") },
+        onDismiss: { print("Dismissed") }
+    )
+    .padding()
+    .frame(width: 400)
+}
+```
+
+**Step 2: Verify build**
+
+```bash
+cd /Users/chaseeasterling/selene-n8n/.worktrees/sub-project-suggestions/SeleneChat
+swift build
+```
+
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add SeleneChat/Sources/Views/Planning/SubprojectSuggestionCard.swift
+git commit -m "feat(ui): add SubprojectSuggestionCard view"
+```
+
+---
+
+## Task 5: Integrate Suggestions into PlanningView
+
+**Files:**
+- Modify: `SeleneChat/Sources/Views/PlanningView.swift`
+
+**Step 1: Add service and state**
+
+At the top of PlanningView struct, after existing @State vars:
+
+```swift
+// Phase 7.2f: Sub-project suggestions
+@StateObject private var suggestionService = SubprojectSuggestionService.shared
+@State private var isSuggestionsExpanded = true
+```
+
+**Step 2: Add suggestions section**
+
+After `needsReviewSection` in the ScrollView VStack, add:
+
+```swift
+// Phase 7.2f: Sub-project suggestions
+if !suggestionService.suggestions.isEmpty {
+    suggestionsSection
+        .id("suggestions")
+}
+```
+
+**Step 3: Add sidebar button**
+
+After the "Needs Review" sidebar button, add:
+
+```swift
+if !suggestionService.suggestions.isEmpty {
+    sidebarButton(
+        icon: "lightbulb.fill",
+        label: "Suggestions",
+        count: suggestionService.suggestions.count,
+        color: .yellow,
+        isExpanded: $isSuggestionsExpanded
+    )
+}
+```
+
+**Step 4: Add suggestionsSection computed property**
+
+After `needsReviewSection`, add:
+
+```swift
+// MARK: - Phase 7.2f: Suggestions Section
+
+private var suggestionsSection: some View {
+    VStack(alignment: .leading, spacing: 0) {
+        // Section header
+        Button(action: { withAnimation { isSuggestionsExpanded.toggle() } }) {
+            HStack {
+                Image(systemName: "lightbulb.fill")
+                    .foregroundColor(.yellow)
+                Text("Suggestions")
+                    .font(.headline)
+
+                Text("(\(suggestionService.suggestions.count))")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Spacer()
+
+                Image(systemName: isSuggestionsExpanded ? "chevron.down" : "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+
+        if isSuggestionsExpanded {
+            Divider()
+
+            LazyVStack(spacing: 12) {
+                ForEach(suggestionService.suggestions) { suggestion in
+                    SubprojectSuggestionCard(
+                        suggestion: suggestion,
+                        onApprove: {
+                            Task {
+                                do {
+                                    _ = try await suggestionService.approve(suggestion)
+                                } catch {
+                                    #if DEBUG
+                                    print("[PlanningView] Approve error: \(error)")
+                                    #endif
+                                }
+                            }
+                        },
+                        onDismiss: {
+                            Task {
+                                try? await suggestionService.dismiss(suggestion)
+                            }
+                        }
+                    )
+                }
+            }
+            .padding()
+        }
+    }
+}
+```
+
+**Step 5: Add detection to syncThingsAndEvaluateTriggers**
+
+In `syncThingsAndEvaluateTriggers()`, after the existing sync logic, add:
+
+```swift
+// Phase 7.2f: Detect sub-project candidates
+suggestionService.configure(with: databaseService.db!)
+_ = try? await suggestionService.detectCandidates()
+```
+
+**Step 6: Verify build**
+
+```bash
+cd /Users/chaseeasterling/selene-n8n/.worktrees/sub-project-suggestions/SeleneChat
+swift build
+```
+
+Expected: Build succeeds
+
+**Step 7: Commit**
+
+```bash
+git add SeleneChat/Sources/Views/PlanningView.swift
+git commit -m "feat(ui): integrate SubprojectSuggestions into PlanningView"
+```
+
+---
+
+## Task 6: Configure Service in DatabaseService
+
+**Files:**
+- Modify: `SeleneChat/Sources/Services/DatabaseService.swift`
+
+**Step 1: Configure SubprojectSuggestionService after migrations**
+
+After the migration runs (around line 100), add:
+
+```swift
+// Configure services that need database access
+SubprojectSuggestionService.shared.configure(with: db!)
+```
+
+**Step 2: Verify build**
+
+```bash
+cd /Users/chaseeasterling/selene-n8n/.worktrees/sub-project-suggestions/SeleneChat
+swift build
+```
+
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add SeleneChat/Sources/Services/DatabaseService.swift
+git commit -m "feat(service): configure SubprojectSuggestionService on database connect"
+```
+
+---
+
+## Task 7: Manual Testing
+
+**Step 1: Build the app**
+
+```bash
+cd /Users/chaseeasterling/selene-n8n/.worktrees/sub-project-suggestions/SeleneChat
+swift build
+```
+
+**Step 2: Run the app**
+
+```bash
+swift run
+```
+
+**Step 3: Test scenarios**
+
+1. Open Planning tab
+2. If you have 5+ tasks in a project with shared sub-concept, a suggestion card should appear
+3. Click "Create Project" → should create project in Things and move tasks
+4. Click "Not Now" → suggestion should disappear and not return
+
+**Step 4: Document test results**
+
+Update BRANCH-STATUS.md with test results.
+
+---
+
+## Task 8: Update Documentation
+
+**Files:**
+- Modify: `BRANCH-STATUS.md`
+- Modify: `docs/plans/INDEX.md`
+
+**Step 1: Update BRANCH-STATUS.md**
+
+Mark planning as complete, move to testing stage.
+
+**Step 2: Add to docs/plans/INDEX.md**
+
+```markdown
+| 2026-01-02-subproject-suggestions-implementation | Sub-Project Suggestions (7.2f) | In Progress | phase-7.2f/sub-project-suggestions |
+```
+
+**Step 3: Commit**
+
+```bash
+git add BRANCH-STATUS.md docs/plans/INDEX.md docs/plans/2026-01-02-subproject-suggestions-implementation.md
+git commit -m "docs: add 7.2f implementation plan"
+```
+
+---
+
+## Summary
+
+**Files Created:**
+- `SeleneChat/Sources/Services/Migrations/Migration004_SubprojectSuggestions.swift`
+- `SeleneChat/Sources/Models/SubprojectSuggestion.swift`
+- `SeleneChat/Sources/Services/SubprojectSuggestionService.swift`
+- `SeleneChat/Sources/Views/Planning/SubprojectSuggestionCard.swift`
+- `docs/plans/2026-01-02-subproject-suggestions-implementation.md`
+
+**Files Modified:**
+- `SeleneChat/Sources/Services/DatabaseService.swift` (migration + service config)
+- `SeleneChat/Sources/Views/PlanningView.swift` (suggestions section)
+- `BRANCH-STATUS.md`
+- `docs/plans/INDEX.md`
+
+**Testing:**
+- Build succeeds after each task
+- Manual testing with Things 3 app
+- Approve/dismiss actions work correctly

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -20,6 +20,7 @@ Status legend:
 | 2026-01-02 | selenechat-auto-builder-design.md | infra | Post-merge hook for auto builds |
 | 2026-01-02 | feedback-pipeline-design.md | infra | AI classification of #selene-feedback → backlog |
 | 2026-01-02 | selenechat-uat-system-design.md | infra | Interactive UAT for SeleneChat views |
+| 2026-01-02 | planning-persistence-refinement-design.md | 7.2g | Conversation persistence + task refinement |
 
 ---
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -30,6 +30,7 @@ Status legend:
 |------|----------|-------|
 | 2026-01-02 | bidirectional-things-implementation.md | Implementation plan for 7.2e |
 | 2026-01-01 | project-grouping-7.2f.1-implementation.md | Implementation plan for 7.2f |
+| 2026-01-02 | subproject-suggestions-implementation.md | Implementation plan for 7.2f sub-project suggestions |
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 7.2f implementation: When a Things project has 5+ tasks sharing a distinct sub-concept, surface a suggestion card in SeleneChat's PlanningView for the user to spin it off as its own project.

**Key Features:**
- Detection: Scans projects for 5+ tasks sharing a sub-concept distinct from the project's primary concept
- Suggestion Card: Yellow-accented card with "Create Project" and "Not Now" buttons
- Approve: Creates new Things project and moves tasks to it
- Dismiss: Suppresses future suggestions for that concept

**Files Created:**
- `Migration004_SubprojectSuggestions.swift` - Database table for tracking suggestions
- `SubprojectSuggestion.swift` - Model with pending/approved/dismissed states
- `SubprojectSuggestionService.swift` - Detection logic and approve/dismiss actions
- `SubprojectSuggestionCard.swift` - SwiftUI card component

**Files Modified:**
- `PlanningView.swift` - Integrated suggestions section
- `DatabaseService.swift` - Service configuration on connect

## Test Plan

- [x] Build passes (`swift build`)
- [x] Code review completed and feedback addressed
- [ ] Manual UAT: Open Planning tab with 5+ tasks sharing a sub-concept
- [ ] Verify approve creates Things project
- [ ] Verify dismiss hides suggestion permanently

🤖 Generated with [Claude Code](https://claude.com/claude-code)