### PR TITLE
feat: Planning Tab Redesign - Projects contain threads

### DIFF
--- a/BRANCH-STATUS.md
+++ b/BRANCH-STATUS.md
@@ -1,106 +1,91 @@
-# Branch Status: infra/feedback-pipeline
+# Branch: phase-7.2/planning-tab-redesign
 
-**Created:** 2026-01-02
-**Design Doc:** docs/plans/2026-01-02-feedback-pipeline-design.md
-**Implementation Plan:** docs/plans/2026-01-02-feedback-pipeline-implementation.md
-**Current Stage:** review
+**Created:** 2026-01-03
+**Status:** Development
+**Design:** `docs/plans/2026-01-03-planning-tab-redesign.md`
+**Implementation Plan:** `docs/plans/2026-01-03-planning-tab-implementation.md`
 **Last Rebased:** 2026-01-03
-
-## Overview
-
-Extend Workflow 01 to classify `#selene-feedback` notes using Ollama and append structured items to backlog. Categories: user_story, feature_request, bug, improvement, noise.
-
-## Dependencies
-
-- Workflow 01 (Ingestion) - must be working
-- Ollama running with mistral:7b
-- `feedback_notes` table exists (migration 009)
 
 ---
 
-## Stages
+## Overview
+
+Restructure Planning tab so projects contain threads, Active Projects appears first, and no standalone conversations exist.
+
+## Key Changes
+
+- Section order: Active Projects -> Scratch Pad (if populated) -> Suggestions -> Inbox -> Parked
+- Projects contain sub-topic threads with focused conversations
+- Thread auto-naming from first message
+- Scratch Pad as default catch-all project (hidden until populated)
+- Resurface alerts as badges on projects, not separate section
+- One SeleneChat project = One Things project, threads = headings
+
+---
+
+## Stage Checklist
 
 ### Planning
-- [x] Design doc exists and approved
-- [x] Conflict check completed (no overlapping work)
-- [x] Dependencies identified and noted
-- [x] Branch and worktree created
+- [x] Design document created
+- [x] Open questions resolved
+- [x] Worktree created
 - [x] Implementation plan written
 
-### Dev
-- [x] Migration 012 created and applied
-- [x] Backlog file format created
-- [x] Classification prompt template created
-- [x] Workflow 01 nodes added (8 new nodes)
-- [x] Workflow updated in n8n
-- [x] All builds/imports succeed
-- [x] Code follows project patterns
+### Development
+- [ ] Task 1: Database migration (Migration005_ProjectThreads)
+- [ ] Task 2: Update DiscussionThread model
+- [ ] Task 3: Update Project model
+- [ ] Task 4: Add thread CRUD to DatabaseService
+- [ ] Task 5: Update ProjectService
+- [ ] Task 6: Create ThreadListView
+- [ ] Task 7: Create StartConversationSheet
+- [ ] Task 8: Update ProjectDetailView
+- [ ] Task 9: Update PlanningView sections
+- [ ] Task 10: Update ActiveProjectsList
+- [ ] Task 11: Update sidebar navigation
+- [ ] Task 12: Final build and test
 
 ### Testing
-- [x] Test script created
-- [x] Feature request classification works (verified: FR-001 to FR-004)
-- [x] User story classification works (LLM classifies as feature_request - acceptable)
-- [x] Bug report classification works (verified: BUG-001, BUG-002)
-- [x] Noise filtering works (verified: 4 notes correctly marked as noise)
-- [x] Duplicate detection works (inherited from existing ingestion)
-- [x] Existing ingestion tests still pass
-- [x] Verified with superpowers:verification-before-completion
+- [ ] Build passes
+- [ ] Manual testing complete
+- [ ] Edge cases verified
 
-### Docs
-- [x] Workflow 01 STATUS.md updated
-- [x] Test results documented in BRANCH-STATUS.md
+### Documentation
+- [ ] CLAUDE.md updated if needed
+- [ ] README updates if user-facing
 
 ### Review
-- [ ] Requested review (superpowers:requesting-code-review)
-- [ ] Review feedback addressed
-- [ ] Changes approved
+- [ ] Code review requested
+- [ ] Feedback addressed
 
 ### Ready
-- [ ] Rebased on latest main
-- [ ] Final test pass after rebase
-- [ ] BRANCH-STATUS.md fully checked
+- [ ] All tests pass
 - [ ] Ready for merge
 
 ---
 
-## Implementation Tasks
+## Files to Modify
 
-| # | Task | Status |
-|---|------|--------|
-| 1 | Create migration 012 | Done |
-| 2 | Create backlog file format | Done |
-| 3 | Create classification prompt | Done |
-| 4 | Export Workflow 01 (backup) | Done |
-| 5 | Add classification nodes | Done |
-| 6 | Update workflow in n8n | Done |
-| 7 | Create test script | Done |
-| 8 | Run tests and verify | Done |
-| 9 | Update documentation | Done |
-| 10 | Final verification and PR | In Progress |
+### Database
+- `Migration005_ProjectThreads.swift` - New migration for thread structure
+
+### Models
+- `DiscussionThread.swift` - Add project_id, thread_name
+- `Project.swift` - Add isSystem, threadCount, hasReviewBadge
+
+### Services
+- `DatabaseService.swift` - Thread CRUD operations
+- `ProjectService.swift` - Thread management
+
+### Views
+- `PlanningView.swift` - Reorder sections, remove standalone threads section
+- `ProjectDetailView.swift` - Add thread list
+- `ThreadListView.swift` - New component
+- `StartConversationSheet.swift` - New component for project picker
 
 ---
 
 ## Notes
 
-- Using test_run markers for all testing
-- Backlog data stored in database, generate-backlog.sh exports to markdown
-- 8 new nodes added (was planned as 7, added Skip Classification? node)
-- Fixed IF node conditions to use boolean expressions instead of string operations
-- Fixed Ollama HTTP node to use POST method
-
-### Verification Results (2026-01-03)
-
-| Category | Count | IDs |
-|----------|-------|-----|
-| feature_request | 4 | FR-001 to FR-004 |
-| bug | 2 | BUG-001, BUG-002 |
-| noise | 4 | (correctly filtered) |
-
-**LLM Note:** User stories classified as feature_request (acceptable - categories overlap).
-Some noise notes misclassified by LLM - can tune prompt later but not a pipeline bug.
-
----
-
-## Blocked Items
-
-(none)
+- Existing standalone threads will migrate to Scratch Pad project
+- System Scratch Pad project created in migration (is_system = 1)

--- a/BRANCH-STATUS.md
+++ b/BRANCH-STATUS.md
@@ -1,7 +1,7 @@
 # Branch: phase-7.2/planning-tab-redesign
 
 **Created:** 2026-01-03
-**Status:** Development
+**Status:** Testing
 **Design:** `docs/plans/2026-01-03-planning-tab-redesign.md`
 **Implementation Plan:** `docs/plans/2026-01-03-planning-tab-implementation.md`
 **Last Rebased:** 2026-01-03
@@ -32,21 +32,21 @@ Restructure Planning tab so projects contain threads, Active Projects appears fi
 - [x] Implementation plan written
 
 ### Development
-- [ ] Task 1: Database migration (Migration005_ProjectThreads)
-- [ ] Task 2: Update DiscussionThread model
-- [ ] Task 3: Update Project model
-- [ ] Task 4: Add thread CRUD to DatabaseService
-- [ ] Task 5: Update ProjectService
-- [ ] Task 6: Create ThreadListView
-- [ ] Task 7: Create StartConversationSheet
-- [ ] Task 8: Update ProjectDetailView
-- [ ] Task 9: Update PlanningView sections
-- [ ] Task 10: Update ActiveProjectsList
-- [ ] Task 11: Update sidebar navigation
-- [ ] Task 12: Final build and test
+- [x] Task 1: Database migration (Migration005_ProjectThreads)
+- [x] Task 2: Update DiscussionThread model
+- [x] Task 3: Update Project model
+- [x] Task 4: Add thread CRUD to DatabaseService
+- [x] Task 5: Update ProjectService
+- [x] Task 6: Create ThreadListView
+- [x] Task 7: Create StartConversationSheet
+- [x] Task 8: Update ProjectDetailView
+- [x] Task 9: Update PlanningView sections
+- [x] Task 10: Update ActiveProjectsList
+- [x] Task 11: Update sidebar navigation
+- [x] Task 12: Final build and test
 
 ### Testing
-- [ ] Build passes
+- [x] Build passes
 - [ ] Manual testing complete
 - [ ] Edge cases verified
 
@@ -64,24 +64,23 @@ Restructure Planning tab so projects contain threads, Active Projects appears fi
 
 ---
 
-## Files to Modify
+## Implementation Summary
 
-### Database
-- `Migration005_ProjectThreads.swift` - New migration for thread structure
+### Commits (12)
+1. `69e358a` - feat(db): add Migration005 for thread-project relationship
+2. `9279372` - feat(model): add projectId and threadName to DiscussionThread
+3. `570b135` - feat(model): add isSystem, threadCount, hasReviewBadge to Project
+4. `9eadf84` - feat(db): add thread-project CRUD operations
+5. `1d9ef31` - feat(service): add thread count and review badge to ProjectService
+6. `6e7af6f` - feat(view): add ThreadListView component
+7. `498ae55` - feat(view): add StartConversationSheet for project picker
+8. `e6308b9` - feat(view): add thread list to ProjectDetailView
+9. `08cc1be` - feat(view): reorder Planning tab sections, add Scratch Pad
+10. `15bdbc4` - feat(view): add review badge and thread count to project rows
 
-### Models
-- `DiscussionThread.swift` - Add project_id, thread_name
-- `Project.swift` - Add isSystem, threadCount, hasReviewBadge
-
-### Services
-- `DatabaseService.swift` - Thread CRUD operations
-- `ProjectService.swift` - Thread management
-
-### Views
-- `PlanningView.swift` - Reorder sections, remove standalone threads section
-- `ProjectDetailView.swift` - Add thread list
-- `ThreadListView.swift` - New component
-- `StartConversationSheet.swift` - New component for project picker
+### Files Changed
+- **New files:** Migration005_ProjectThreads.swift, ThreadListView.swift, StartConversationSheet.swift
+- **Modified:** DiscussionThread.swift, Project.swift, DatabaseService.swift, ProjectService.swift, ProjectDetailView.swift, PlanningView.swift, ActiveProjectsList.swift
 
 ---
 
@@ -89,3 +88,4 @@ Restructure Planning tab so projects contain threads, Active Projects appears fi
 
 - Existing standalone threads will migrate to Scratch Pad project
 - System Scratch Pad project created in migration (is_system = 1)
+- Legacy needsReviewSection and planningThreadsSection kept for backward compatibility but no longer shown in main view

--- a/SeleneChat/Sources/Models/DiscussionThread.swift
+++ b/SeleneChat/Sources/Models/DiscussionThread.swift
@@ -4,6 +4,8 @@ struct DiscussionThread: Identifiable, Hashable {
     let id: Int
     let rawNoteId: Int
     let threadType: ThreadType
+    var projectId: Int?
+    var threadName: String?
     let prompt: String
     var status: Status
     let createdAt: Date

--- a/SeleneChat/Sources/Models/Project.swift
+++ b/SeleneChat/Sources/Models/Project.swift
@@ -10,11 +10,14 @@ struct Project: Identifiable, Hashable, Codable {
     var lastActiveAt: Date?
     var completedAt: Date?
     var testRun: String?
+    var isSystem: Bool = false
 
     // Computed from joins
     var noteCount: Int = 0
     var taskCount: Int = 0
     var completedTaskCount: Int = 0
+    var threadCount: Int = 0
+    var hasReviewBadge: Bool = false
 
     enum Status: String, CaseIterable, Codable {
         case active

--- a/SeleneChat/Sources/Services/DatabaseService.swift
+++ b/SeleneChat/Sources/Services/DatabaseService.swift
@@ -99,6 +99,7 @@ class DatabaseService: ObservableObject {
             try? Migration002_PlanningInbox.run(db: db!)
             try? Migration003_BidirectionalThings.run(db: db!)
             try? Migration004_SubprojectSuggestions.run(db: db!)
+            try? Migration005_ProjectThreads.run(db: db!)
 
             // Configure services that need database access
             if let db = db {

--- a/SeleneChat/Sources/Services/DatabaseService.swift
+++ b/SeleneChat/Sources/Services/DatabaseService.swift
@@ -74,6 +74,8 @@ class DatabaseService: ObservableObject {
     private let threadCompletedAt = Expression<String?>("completed_at")
     private let threadRelatedConcepts = Expression<String?>("related_concepts")
     private let threadTestRun = Expression<String?>("test_run")
+    private let threadProjectId = Expression<Int64?>("project_id")
+    private let threadName = Expression<String?>("thread_name")
 
     init() {
         // Try to load saved path, otherwise use default
@@ -988,6 +990,135 @@ class DatabaseService: ObservableObject {
             noteTitle: noteTitle,
             noteContent: noteContent
         )
+    }
+
+    // MARK: - Thread-Project Operations
+
+    func fetchThreadsForProject(_ projectIdValue: Int) async throws -> [DiscussionThread] {
+        guard let db = db else {
+            throw DatabaseError.notConnected
+        }
+
+        let query = discussionThreads
+            .filter(threadProjectId == Int64(projectIdValue))
+            .filter(threadTestRun == nil)
+            .order(threadCreatedAt.desc)
+
+        var threads: [DiscussionThread] = []
+        let dateFormatter = ISO8601DateFormatter()
+
+        for row in try db.prepare(query) {
+            var thread = DiscussionThread(
+                id: Int(row[threadId]),
+                rawNoteId: Int(row[threadRawNoteId]),
+                threadType: DiscussionThread.ThreadType(rawValue: row[threadType]) ?? .planning,
+                projectId: row[threadProjectId].map { Int($0) },
+                threadName: row[threadName],
+                prompt: row[threadPrompt],
+                status: DiscussionThread.Status(rawValue: row[threadStatus]) ?? .pending,
+                createdAt: dateFormatter.date(from: row[threadCreatedAt]) ?? Date(),
+                surfacedAt: row[threadSurfacedAt].flatMap { dateFormatter.date(from: $0) },
+                completedAt: row[threadCompletedAt].flatMap { dateFormatter.date(from: $0) },
+                relatedConcepts: row[threadRelatedConcepts].flatMap { try? JSONDecoder().decode([String].self, from: $0.data(using: .utf8)!) }
+            )
+            threads.append(thread)
+        }
+
+        return threads
+    }
+
+    func createThread(
+        projectId: Int,
+        rawNoteId: Int,
+        threadType: DiscussionThread.ThreadType,
+        prompt: String
+    ) async throws -> DiscussionThread {
+        guard let db = db else {
+            throw DatabaseError.notConnected
+        }
+
+        let dateFormatter = ISO8601DateFormatter()
+        let now = dateFormatter.string(from: Date())
+
+        let insertId = try db.run(discussionThreads.insert(
+            threadRawNoteId <- Int64(rawNoteId),
+            self.threadType <- threadType.rawValue,
+            threadPrompt <- prompt,
+            threadStatus <- "pending",
+            threadCreatedAt <- now,
+            threadProjectId <- Int64(projectId)
+        ))
+
+        return DiscussionThread(
+            id: Int(insertId),
+            rawNoteId: rawNoteId,
+            threadType: threadType,
+            projectId: projectId,
+            threadName: nil,
+            prompt: prompt,
+            status: .pending,
+            createdAt: Date(),
+            surfacedAt: nil,
+            completedAt: nil,
+            relatedConcepts: nil
+        )
+    }
+
+    func updateThreadName(_ threadIdValue: Int, name: String) async throws {
+        guard let db = db else {
+            throw DatabaseError.notConnected
+        }
+
+        let thread = discussionThreads.filter(threadId == Int64(threadIdValue))
+        try db.run(thread.update(threadName <- name))
+    }
+
+    func moveThreadToProject(_ threadIdValue: Int, projectId: Int) async throws {
+        guard let db = db else {
+            throw DatabaseError.notConnected
+        }
+
+        let thread = discussionThreads.filter(threadId == Int64(threadIdValue))
+        try db.run(thread.update(threadProjectId <- Int64(projectId)))
+    }
+
+    func getScratchPadProject() async throws -> Project? {
+        guard let db = db else {
+            throw DatabaseError.notConnected
+        }
+
+        let projects = Table("projects")
+        let isSystem = Expression<Int64>("is_system")
+        let query = projects.filter(isSystem == 1).limit(1)
+
+        guard let row = try db.pluck(query) else { return nil }
+
+        let dateFormatter = ISO8601DateFormatter()
+        let projectId = Expression<Int64>("id")
+        let projectName = Expression<String>("name")
+        let projectStatus = Expression<String>("status")
+        let projectCreatedAt = Expression<String>("created_at")
+
+        return Project(
+            id: Int(row[projectId]),
+            name: row[projectName],
+            status: Project.Status(rawValue: row[projectStatus]) ?? .active,
+            createdAt: dateFormatter.date(from: row[projectCreatedAt]) ?? Date(),
+            isSystem: true
+        )
+    }
+
+    func hasProjectReviewBadge(_ projectIdValue: Int) async throws -> Bool {
+        guard let db = db else { return false }
+
+        // Check if any thread in this project has status = 'review'
+        let count = try db.scalar(
+            discussionThreads
+                .filter(threadProjectId == Int64(projectIdValue))
+                .filter(threadStatus == "review")
+                .count
+        )
+        return count > 0
     }
 
     // MARK: - Error Types

--- a/SeleneChat/Sources/Services/Migrations/Migration005_ProjectThreads.swift
+++ b/SeleneChat/Sources/Services/Migrations/Migration005_ProjectThreads.swift
@@ -1,0 +1,59 @@
+// Migration005_ProjectThreads.swift
+// SeleneChat
+//
+// Phase 7.2: Planning Tab Redesign
+// Adds project_id and thread_name to discussion_threads
+// Creates system Scratch Pad project
+
+import Foundation
+import SQLite
+
+struct Migration005_ProjectThreads {
+    static func run(db: Connection) throws {
+        // Add project_id column (nullable for migration, will default to Scratch Pad)
+        try db.run("""
+            ALTER TABLE discussion_threads ADD COLUMN project_id INTEGER
+            REFERENCES projects(id)
+        """)
+
+        // Add thread_name column (auto-generated from first message)
+        try db.run("""
+            ALTER TABLE discussion_threads ADD COLUMN thread_name TEXT
+        """)
+
+        // Create index for quick project->threads lookup
+        try db.run("""
+            CREATE INDEX IF NOT EXISTS idx_threads_project
+            ON discussion_threads(project_id)
+        """)
+
+        // Add is_system column to projects if not exists
+        do {
+            try db.run("ALTER TABLE projects ADD COLUMN is_system INTEGER DEFAULT 0")
+        } catch {
+            // Column may already exist
+        }
+
+        // Create system Scratch Pad project (is_system=1)
+        try db.run("""
+            INSERT OR IGNORE INTO projects (name, status, is_system, created_at, last_active_at)
+            VALUES ('Scratch Pad', 'active', 1, datetime('now'), datetime('now'))
+        """)
+
+        // Get the Scratch Pad project ID
+        let scratchPadId = try db.scalar(
+            "SELECT id FROM projects WHERE is_system = 1 LIMIT 1"
+        ) as? Int64
+
+        // Migrate existing orphan threads to Scratch Pad
+        if let scratchPadId = scratchPadId {
+            try db.run("""
+                UPDATE discussion_threads
+                SET project_id = \(scratchPadId)
+                WHERE project_id IS NULL
+            """)
+        }
+
+        print("Migration 005: project_id added to discussion_threads, Scratch Pad created")
+    }
+}

--- a/SeleneChat/Sources/Views/Planning/ActiveProjectsList.swift
+++ b/SeleneChat/Sources/Views/Planning/ActiveProjectsList.swift
@@ -92,13 +92,25 @@ struct ProjectRowView: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 4) {
-                Text(project.name)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
+                HStack(spacing: 6) {
+                    Text(project.name)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+
+                    // Review badge if any thread needs review
+                    if project.hasReviewBadge {
+                        Image(systemName: "bell.badge.fill")
+                            .foregroundColor(.orange)
+                            .font(.caption)
+                    }
+                }
 
                 HStack(spacing: 8) {
-                    Label("\(project.noteCount)", systemImage: "doc")
+                    Label("\(project.threadCount) threads", systemImage: "bubble.left.and.bubble.right")
+                    Text("\u{2022}")
+                    Label("\(project.noteCount) notes", systemImage: "doc")
                     if let time = project.timeSinceActive {
+                        Text("\u{2022}")
                         Text(time)
                     }
                 }

--- a/SeleneChat/Sources/Views/Planning/StartConversationSheet.swift
+++ b/SeleneChat/Sources/Views/Planning/StartConversationSheet.swift
@@ -1,0 +1,235 @@
+// StartConversationSheet.swift
+// SeleneChat
+//
+// Phase 7.2: Planning Tab Redesign
+// Project picker when starting a new conversation
+
+import SwiftUI
+
+struct StartConversationSheet: View {
+    let note: InboxNote
+    let onStart: (Int, String?) -> Void  // projectId, new project name if creating
+    let onCancel: () -> Void
+
+    @EnvironmentObject var databaseService: DatabaseService
+    @StateObject private var projectService = ProjectService.shared
+
+    @State private var selection: Selection = .scratchPad
+    @State private var newProjectName = ""
+    @State private var activeProjects: [Project] = []
+    @State private var parkedProjects: [Project] = []
+    @State private var scratchPad: Project?
+    @State private var isLoading = true
+
+    enum Selection: Hashable {
+        case scratchPad
+        case existing(Int)
+        case new
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Start Conversation")
+                    .font(.headline)
+                Spacer()
+                Button(action: onCancel) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding()
+
+            Divider()
+
+            // Note preview
+            VStack(alignment: .leading, spacing: 4) {
+                Text(note.title)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Text(note.preview)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.accentColor.opacity(0.05))
+
+            Divider()
+
+            // Options
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Where should this conversation live?")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal)
+
+                    // Scratch Pad option
+                    if scratchPad != nil {
+                        optionRow(
+                            icon: "note.text",
+                            title: "Scratch Pad",
+                            subtitle: "Quick thought, organize later",
+                            isSelected: selection == .scratchPad
+                        ) {
+                            selection = .scratchPad
+                        }
+                    }
+
+                    // Create new project
+                    optionRow(
+                        icon: "plus.circle",
+                        title: "Create New Project",
+                        subtitle: newProjectName.isEmpty ? "Enter name below" : newProjectName,
+                        isSelected: selection == .new
+                    ) {
+                        selection = .new
+                    }
+
+                    if selection == .new {
+                        TextField("Project name", text: $newProjectName)
+                            .textFieldStyle(.roundedBorder)
+                            .padding(.horizontal)
+                    }
+
+                    // Existing projects
+                    if !activeProjects.isEmpty {
+                        Text("Active Projects")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal)
+                            .padding(.top, 8)
+
+                        ForEach(activeProjects) { project in
+                            optionRow(
+                                icon: "star.fill",
+                                title: project.name,
+                                subtitle: "\(project.threadCount) threads",
+                                isSelected: selection == .existing(project.id)
+                            ) {
+                                selection = .existing(project.id)
+                            }
+                        }
+                    }
+
+                    if !parkedProjects.isEmpty {
+                        Text("Parked Projects")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal)
+                            .padding(.top, 8)
+
+                        ForEach(parkedProjects.prefix(5)) { project in
+                            optionRow(
+                                icon: "moon.zzz",
+                                title: project.name,
+                                subtitle: "\(project.threadCount) threads",
+                                isSelected: selection == .existing(project.id)
+                            ) {
+                                selection = .existing(project.id)
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical)
+            }
+
+            Divider()
+
+            // Actions
+            HStack {
+                Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.escape)
+
+                Spacer()
+
+                Button("Start Conversation") {
+                    startConversation()
+                }
+                .keyboardShortcut(.return)
+                .buttonStyle(.borderedProminent)
+                .disabled(!canStart)
+            }
+            .padding()
+        }
+        .frame(width: 400, height: 500)
+        .task {
+            await loadProjects()
+        }
+    }
+
+    private func optionRow(
+        icon: String,
+        title: String,
+        subtitle: String,
+        isSelected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(isSelected ? .accentColor : .secondary)
+
+                Image(systemName: icon)
+                    .foregroundColor(.secondary)
+                    .frame(width: 20)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.body)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+            .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+            .cornerRadius(8)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var canStart: Bool {
+        switch selection {
+        case .scratchPad, .existing:
+            return true
+        case .new:
+            return !newProjectName.trimmingCharacters(in: .whitespaces).isEmpty
+        }
+    }
+
+    private func loadProjects() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            activeProjects = try await projectService.getActiveProjects()
+            parkedProjects = try await projectService.getParkedProjects()
+            scratchPad = try await projectService.getScratchPad()
+        } catch {
+            #if DEBUG
+            print("[StartConversationSheet] Error: \(error)")
+            #endif
+        }
+    }
+
+    private func startConversation() {
+        switch selection {
+        case .scratchPad:
+            if let pad = scratchPad {
+                onStart(pad.id, nil)
+            }
+        case .existing(let projectId):
+            onStart(projectId, nil)
+        case .new:
+            onStart(-1, newProjectName)  // -1 signals create new
+        }
+    }
+}

--- a/SeleneChat/Sources/Views/Planning/ThreadListView.swift
+++ b/SeleneChat/Sources/Views/Planning/ThreadListView.swift
@@ -1,0 +1,133 @@
+// ThreadListView.swift
+// SeleneChat
+//
+// Phase 7.2: Planning Tab Redesign
+// Displays threads inside a project
+
+import SwiftUI
+
+struct ThreadListView: View {
+    let projectId: Int
+    let onSelectThread: (DiscussionThread) -> Void
+
+    @EnvironmentObject var databaseService: DatabaseService
+    @State private var threads: [DiscussionThread] = []
+    @State private var isLoading = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding()
+            } else if threads.isEmpty {
+                emptyState
+            } else {
+                LazyVStack(spacing: 8) {
+                    ForEach(threads, id: \.id) { thread in
+                        ThreadRow(thread: thread)
+                            .onTapGesture {
+                                onSelectThread(thread)
+                            }
+                    }
+                }
+                .padding()
+            }
+        }
+        .task {
+            await loadThreads()
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(.largeTitle)
+                .foregroundColor(.secondary)
+            Text("No threads yet")
+                .font(.headline)
+                .foregroundColor(.secondary)
+            Text("Start a conversation to create a thread")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 32)
+    }
+
+    private func loadThreads() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            threads = try await databaseService.fetchThreadsForProject(projectId)
+        } catch {
+            #if DEBUG
+            print("[ThreadListView] Error loading threads: \(error)")
+            #endif
+        }
+    }
+}
+
+struct ThreadRow: View {
+    let thread: DiscussionThread
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Status indicator
+            Image(systemName: thread.status.icon)
+                .foregroundColor(statusColor)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 4) {
+                // Thread name or prompt preview
+                Text(displayName)
+                    .font(.body)
+                    .lineLimit(1)
+
+                // Metadata
+                HStack(spacing: 8) {
+                    Label(thread.threadType.displayName, systemImage: thread.threadType.icon)
+                    Text("\u{2022}")
+                    Text(thread.timeSinceCreated)
+                }
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            // Review badge if needed
+            if thread.status == .review {
+                Image(systemName: "bell.badge.fill")
+                    .foregroundColor(.orange)
+            }
+
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(12)
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(8)
+        .contentShape(Rectangle())
+    }
+
+    private var displayName: String {
+        if let name = thread.threadName, !name.isEmpty {
+            return name
+        }
+        let preview = thread.prompt.prefix(50)
+        return preview.count < thread.prompt.count ? "\(preview)..." : String(preview)
+    }
+
+    private var statusColor: Color {
+        switch thread.status {
+        case .pending: return .gray
+        case .active: return .blue
+        case .completed: return .green
+        case .dismissed: return .secondary
+        case .review: return .orange
+        }
+    }
+}

--- a/SeleneChat/Sources/Views/ProjectDetailView.swift
+++ b/SeleneChat/Sources/Views/ProjectDetailView.swift
@@ -10,6 +10,10 @@ struct ProjectDetailView: View {
     let project: Project
     let onBack: () -> Void
 
+    @EnvironmentObject var databaseService: DatabaseService
+    @State private var selectedThread: DiscussionThread?
+    @State private var showNewThreadSheet = false
+
     var body: some View {
         VStack(spacing: 0) {
             // Header
@@ -82,26 +86,32 @@ struct ProjectDetailView: View {
 
             Divider()
 
-            // Placeholder content
-            Spacer()
+            // Threads section
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    Image(systemName: "bubble.left.and.bubble.right")
+                        .foregroundColor(.blue)
+                    Text("Threads")
+                        .font(.headline)
+                    Text("(\(project.threadCount))")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Button(action: { showNewThreadSheet = true }) {
+                        Image(systemName: "plus")
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding()
 
-            VStack(spacing: 12) {
-                Image(systemName: "hammer.fill")
-                    .font(.system(size: 48))
-                    .foregroundColor(.secondary.opacity(0.5))
+                Divider()
 
-                Text("Project detail view coming soon")
-                    .font(.headline)
-                    .foregroundColor(.secondary)
-
-                Text("This will show project notes, tasks, and planning threads.")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.center)
+                ScrollView {
+                    ThreadListView(projectId: project.id) { thread in
+                        selectedThread = thread
+                    }
+                }
             }
-            .padding()
-
-            Spacer()
         }
         .onAppear {
             #if DEBUG

--- a/docs/plans/2026-01-03-planning-tab-implementation.md
+++ b/docs/plans/2026-01-03-planning-tab-implementation.md
@@ -1,0 +1,1037 @@
+# Planning Tab Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Restructure Planning tab so projects contain threads, Active Projects appears first, and no standalone conversations exist.
+
+**Architecture:** Projects are containers for sub-topic threads. Each thread has its own focused conversation. The Scratch Pad is a system project for loose threads. Section order: Active Projects → Scratch Pad → Suggestions → Inbox → Parked.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, SQLite.swift
+
+**Design Doc:** `docs/plans/2026-01-03-planning-tab-redesign.md`
+
+---
+
+## Task 1: Database Migration - Add Thread-Project Relationship
+
+**Files:**
+- Create: `SeleneChat/Sources/Services/Migrations/Migration005_ProjectThreads.swift`
+- Modify: `SeleneChat/Sources/Services/DatabaseService.swift:100` (add migration call)
+
+**Step 1: Create the migration file**
+
+```swift
+// Migration005_ProjectThreads.swift
+// SeleneChat
+//
+// Phase 7.2: Planning Tab Redesign
+// Adds project_id and thread_name to discussion_threads
+// Creates system Scratch Pad project
+
+import Foundation
+import SQLite
+
+struct Migration005_ProjectThreads {
+    static func run(db: Connection) throws {
+        // Add project_id column (nullable for migration, will default to Scratch Pad)
+        try db.run("""
+            ALTER TABLE discussion_threads ADD COLUMN project_id INTEGER
+            REFERENCES projects(id)
+        """)
+
+        // Add thread_name column (auto-generated from first message)
+        try db.run("""
+            ALTER TABLE discussion_threads ADD COLUMN thread_name TEXT
+        """)
+
+        // Create index for quick project->threads lookup
+        try db.run("""
+            CREATE INDEX IF NOT EXISTS idx_threads_project
+            ON discussion_threads(project_id)
+        """)
+
+        // Create system Scratch Pad project (id=1, is_system=1)
+        try db.run("""
+            INSERT OR IGNORE INTO projects (id, name, status, is_system, created_at, last_active_at)
+            VALUES (1, 'Scratch Pad', 'active', 1, datetime('now'), datetime('now'))
+        """)
+
+        // Add is_system column to projects if not exists
+        do {
+            try db.run("ALTER TABLE projects ADD COLUMN is_system INTEGER DEFAULT 0")
+        } catch {
+            // Column may already exist
+        }
+
+        // Migrate existing orphan threads to Scratch Pad
+        try db.run("""
+            UPDATE discussion_threads
+            SET project_id = 1
+            WHERE project_id IS NULL
+        """)
+
+        print("Migration 005: project_id added to discussion_threads, Scratch Pad created")
+    }
+}
+```
+
+**Step 2: Add migration call to DatabaseService**
+
+In `DatabaseService.swift`, after line 100 (Migration004), add:
+
+```swift
+try? Migration005_ProjectThreads.run(db: db!)
+```
+
+**Step 3: Build to verify migration compiles**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add SeleneChat/Sources/Services/Migrations/Migration005_ProjectThreads.swift
+git add SeleneChat/Sources/Services/DatabaseService.swift
+git commit -m "feat(db): add Migration005 for thread-project relationship"
+```
+
+---
+
+## Task 2: Update DiscussionThread Model
+
+**Files:**
+- Modify: `SeleneChat/Sources/Models/DiscussionThread.swift`
+
+**Step 1: Add new properties to DiscussionThread**
+
+After line 6 (`let threadType: ThreadType`), add:
+
+```swift
+    var projectId: Int?
+    var threadName: String?
+```
+
+**Step 2: Build to verify model compiles**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds (may have warnings about unused properties)
+
+**Step 3: Commit**
+
+```bash
+git add SeleneChat/Sources/Models/DiscussionThread.swift
+git commit -m "feat(model): add projectId and threadName to DiscussionThread"
+```
+
+---
+
+## Task 3: Update Project Model for System Flag
+
+**Files:**
+- Modify: `SeleneChat/Sources/Models/Project.swift`
+
+**Step 1: Add isSystem property**
+
+After line 12 (`var testRun: String?`), add:
+
+```swift
+    var isSystem: Bool = false
+```
+
+**Step 2: Add thread count property**
+
+After line 17 (`var completedTaskCount: Int = 0`), add:
+
+```swift
+    var threadCount: Int = 0
+    var hasReviewBadge: Bool = false
+```
+
+**Step 3: Build to verify**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add SeleneChat/Sources/Models/Project.swift
+git commit -m "feat(model): add isSystem, threadCount, hasReviewBadge to Project"
+```
+
+---
+
+## Task 4: Add Thread CRUD to DatabaseService
+
+**Files:**
+- Modify: `SeleneChat/Sources/Services/DatabaseService.swift`
+
+**Step 1: Add column expressions for new fields**
+
+After line 76 (`private let threadTestRun`), add:
+
+```swift
+    private let threadProjectId = Expression<Int64?>("project_id")
+    private let threadName = Expression<String?>("thread_name")
+```
+
+**Step 2: Add fetchThreadsForProject method**
+
+At the end of the class (before the closing `}`), add:
+
+```swift
+    // MARK: - Thread-Project Operations
+
+    func fetchThreadsForProject(_ projectIdValue: Int) async throws -> [DiscussionThread] {
+        guard let db = db else {
+            throw DatabaseError.notConnected
+        }
+
+        let query = discussionThreads
+            .filter(threadProjectId == Int64(projectIdValue))
+            .filter(threadTestRun == nil)
+            .order(threadCreatedAt.desc)
+
+        var threads: [DiscussionThread] = []
+        let dateFormatter = ISO8601DateFormatter()
+
+        for row in try db.prepare(query) {
+            let thread = DiscussionThread(
+                id: Int(try row.get(threadId)),
+                rawNoteId: Int(try row.get(threadRawNoteId)),
+                threadType: DiscussionThread.ThreadType(rawValue: try row.get(threadType)) ?? .planning,
+                prompt: try row.get(threadPrompt),
+                status: DiscussionThread.Status(rawValue: try row.get(threadStatus)) ?? .pending,
+                createdAt: dateFormatter.date(from: try row.get(threadCreatedAt)) ?? Date(),
+                surfacedAt: (try? row.get(threadSurfacedAt)).flatMap { dateFormatter.date(from: $0) },
+                completedAt: (try? row.get(threadCompletedAt)).flatMap { dateFormatter.date(from: $0) },
+                relatedConcepts: (try? row.get(threadRelatedConcepts)).flatMap { try? JSONDecoder().decode([String].self, from: $0.data(using: .utf8)!) },
+                projectId: (try? row.get(threadProjectId)).map { Int($0) },
+                threadName: try? row.get(threadName)
+            )
+            threads.append(thread)
+        }
+
+        return threads
+    }
+
+    func createThread(
+        projectId: Int,
+        rawNoteId: Int,
+        threadType: DiscussionThread.ThreadType,
+        prompt: String
+    ) async throws -> DiscussionThread {
+        guard let db = db else {
+            throw DatabaseError.notConnected
+        }
+
+        let dateFormatter = ISO8601DateFormatter()
+        let now = dateFormatter.string(from: Date())
+
+        let id = try db.run(discussionThreads.insert(
+            threadRawNoteId <- Int64(rawNoteId),
+            threadType <- threadType.rawValue,
+            threadPrompt <- prompt,
+            threadStatus <- "pending",
+            threadCreatedAt <- now,
+            threadProjectId <- Int64(projectId)
+        ))
+
+        return DiscussionThread(
+            id: Int(id),
+            rawNoteId: rawNoteId,
+            threadType: threadType,
+            prompt: prompt,
+            status: .pending,
+            createdAt: Date(),
+            projectId: projectId
+        )
+    }
+
+    func updateThreadName(_ threadIdValue: Int, name: String) async throws {
+        guard let db = db else {
+            throw DatabaseError.notConnected
+        }
+
+        let thread = discussionThreads.filter(threadId == Int64(threadIdValue))
+        try db.run(thread.update(threadName <- name))
+    }
+
+    func moveThreadToProject(_ threadIdValue: Int, projectId: Int) async throws {
+        guard let db = db else {
+            throw DatabaseError.notConnected
+        }
+
+        let thread = discussionThreads.filter(threadId == Int64(threadIdValue))
+        try db.run(thread.update(threadProjectId <- Int64(projectId)))
+    }
+
+    func getScratchPadProject() async throws -> Project? {
+        guard let db = db else {
+            throw DatabaseError.notConnected
+        }
+
+        let projects = Table("projects")
+        let isSystem = Expression<Int64>("is_system")
+        let query = projects.filter(isSystem == 1).limit(1)
+
+        guard let row = try db.pluck(query) else { return nil }
+
+        let dateFormatter = ISO8601DateFormatter()
+        let projectId = Expression<Int64>("id")
+        let projectName = Expression<String>("name")
+        let projectStatus = Expression<String>("status")
+        let createdAt = Expression<String>("created_at")
+
+        return Project(
+            id: Int(try row.get(projectId)),
+            name: try row.get(projectName),
+            status: Project.Status(rawValue: try row.get(projectStatus)) ?? .active,
+            createdAt: dateFormatter.date(from: try row.get(createdAt)) ?? Date(),
+            isSystem: true
+        )
+    }
+
+    func hasProjectReviewBadge(_ projectIdValue: Int) async throws -> Bool {
+        guard let db = db else { return false }
+
+        // Check if any thread in this project has status = 'review'
+        let count = try db.scalar(
+            discussionThreads
+                .filter(threadProjectId == Int64(projectIdValue))
+                .filter(threadStatus == "review")
+                .count
+        )
+        return count > 0
+    }
+```
+
+**Step 3: Build to verify**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add SeleneChat/Sources/Services/DatabaseService.swift
+git commit -m "feat(db): add thread-project CRUD operations"
+```
+
+---
+
+## Task 5: Update ProjectService for Thread Support
+
+**Files:**
+- Modify: `SeleneChat/Sources/Services/ProjectService.swift`
+
+**Step 1: Add thread count and review badge fetching**
+
+Replace the `parseProject` method and add thread count logic. After `getNoteCount`, add:
+
+```swift
+    private func getThreadCount(for projectIdValue: Int) async throws -> Int {
+        guard let db = db else { return 0 }
+
+        let threads = Table("discussion_threads")
+        let projectId = Expression<Int64?>("project_id")
+        let testRun = Expression<String?>("test_run")
+
+        let count = try db.scalar(
+            threads.filter(projectId == Int64(projectIdValue)).filter(testRun == nil).count
+        )
+        return count
+    }
+
+    private func hasReviewBadge(for projectIdValue: Int) async throws -> Bool {
+        guard let db = db else { return false }
+
+        let threads = Table("discussion_threads")
+        let projectId = Expression<Int64?>("project_id")
+        let status = Expression<String>("status")
+
+        let count = try db.scalar(
+            threads.filter(projectId == Int64(projectIdValue)).filter(status == "review").count
+        )
+        return count > 0
+    }
+```
+
+**Step 2: Update getActiveProjects to include thread count and badge**
+
+In `getActiveProjects`, after `project.noteCount = try await getNoteCount(for: project.id)`, add:
+
+```swift
+            project.threadCount = try await getThreadCount(for: project.id)
+            project.hasReviewBadge = try await hasReviewBadge(for: project.id)
+```
+
+**Step 3: Do the same for getParkedProjects**
+
+**Step 4: Add getScratchPad method**
+
+```swift
+    func getScratchPad() async throws -> Project? {
+        guard let db = db else {
+            throw DatabaseService.DatabaseError.notConnected
+        }
+
+        let isSystem = Expression<Int64>("is_system")
+        let query = projects.filter(isSystem == 1).limit(1)
+
+        guard let row = try db.pluck(query) else { return nil }
+
+        var project = try parseProject(from: row)
+        project.isSystem = true
+        project.threadCount = try await getThreadCount(for: project.id)
+        return project
+    }
+```
+
+**Step 5: Build to verify**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 6: Commit**
+
+```bash
+git add SeleneChat/Sources/Services/ProjectService.swift
+git commit -m "feat(service): add thread count and review badge to ProjectService"
+```
+
+---
+
+## Task 6: Create ThreadListView Component
+
+**Files:**
+- Create: `SeleneChat/Sources/Views/Planning/ThreadListView.swift`
+
+**Step 1: Create the view file**
+
+```swift
+// ThreadListView.swift
+// SeleneChat
+//
+// Phase 7.2: Planning Tab Redesign
+// Displays threads inside a project
+
+import SwiftUI
+
+struct ThreadListView: View {
+    let projectId: Int
+    let onSelectThread: (DiscussionThread) -> Void
+
+    @EnvironmentObject var databaseService: DatabaseService
+    @State private var threads: [DiscussionThread] = []
+    @State private var isLoading = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding()
+            } else if threads.isEmpty {
+                emptyState
+            } else {
+                LazyVStack(spacing: 8) {
+                    ForEach(threads, id: \.id) { thread in
+                        ThreadRow(thread: thread)
+                            .onTapGesture {
+                                onSelectThread(thread)
+                            }
+                    }
+                }
+                .padding()
+            }
+        }
+        .task {
+            await loadThreads()
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(.largeTitle)
+                .foregroundColor(.secondary)
+            Text("No threads yet")
+                .font(.headline)
+                .foregroundColor(.secondary)
+            Text("Start a conversation to create a thread")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 32)
+    }
+
+    private func loadThreads() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            threads = try await databaseService.fetchThreadsForProject(projectId)
+        } catch {
+            #if DEBUG
+            print("[ThreadListView] Error loading threads: \(error)")
+            #endif
+        }
+    }
+}
+
+struct ThreadRow: View {
+    let thread: DiscussionThread
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Status indicator
+            Image(systemName: thread.status.icon)
+                .foregroundColor(statusColor)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 4) {
+                // Thread name or prompt preview
+                Text(thread.threadName ?? thread.prompt.prefix(50) + "...")
+                    .font(.body)
+                    .lineLimit(1)
+
+                // Metadata
+                HStack(spacing: 8) {
+                    Label(thread.threadType.displayName, systemImage: thread.threadType.icon)
+                    Text("•")
+                    Text(thread.timeSinceCreated)
+                }
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            // Review badge if needed
+            if thread.status == .review {
+                Image(systemName: "bell.badge.fill")
+                    .foregroundColor(.orange)
+            }
+
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(12)
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(8)
+        .contentShape(Rectangle())
+    }
+
+    private var statusColor: Color {
+        switch thread.status {
+        case .pending: return .gray
+        case .active: return .blue
+        case .completed: return .green
+        case .dismissed: return .secondary
+        case .review: return .orange
+        }
+    }
+}
+```
+
+**Step 2: Build to verify**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add SeleneChat/Sources/Views/Planning/ThreadListView.swift
+git commit -m "feat(view): add ThreadListView component"
+```
+
+---
+
+## Task 7: Create StartConversationSheet Component
+
+**Files:**
+- Create: `SeleneChat/Sources/Views/Planning/StartConversationSheet.swift`
+
+**Step 1: Create the sheet view**
+
+```swift
+// StartConversationSheet.swift
+// SeleneChat
+//
+// Phase 7.2: Planning Tab Redesign
+// Project picker when starting a new conversation
+
+import SwiftUI
+
+struct StartConversationSheet: View {
+    let note: InboxNote
+    let onStart: (Int, String?) -> Void  // projectId, new project name if creating
+    let onCancel: () -> Void
+
+    @EnvironmentObject var databaseService: DatabaseService
+    @StateObject private var projectService = ProjectService.shared
+
+    @State private var selection: Selection = .scratchPad
+    @State private var newProjectName = ""
+    @State private var activeProjects: [Project] = []
+    @State private var parkedProjects: [Project] = []
+    @State private var scratchPad: Project?
+    @State private var isLoading = true
+
+    enum Selection: Hashable {
+        case scratchPad
+        case existing(Int)
+        case new
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Start Conversation")
+                    .font(.headline)
+                Spacer()
+                Button(action: onCancel) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding()
+
+            Divider()
+
+            // Note preview
+            VStack(alignment: .leading, spacing: 4) {
+                Text(note.title)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Text(note.content.prefix(100) + "...")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.accentColor.opacity(0.05))
+
+            Divider()
+
+            // Options
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Where should this conversation live?")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal)
+
+                    // Scratch Pad option
+                    if let pad = scratchPad {
+                        optionRow(
+                            icon: "note.text",
+                            title: "Scratch Pad",
+                            subtitle: "Quick thought, organize later",
+                            isSelected: selection == .scratchPad
+                        ) {
+                            selection = .scratchPad
+                        }
+                    }
+
+                    // Create new project
+                    optionRow(
+                        icon: "plus.circle",
+                        title: "Create New Project",
+                        subtitle: newProjectName.isEmpty ? "Enter name below" : newProjectName,
+                        isSelected: selection == .new
+                    ) {
+                        selection = .new
+                    }
+
+                    if selection == .new {
+                        TextField("Project name", text: $newProjectName)
+                            .textFieldStyle(.roundedBorder)
+                            .padding(.horizontal)
+                    }
+
+                    // Existing projects
+                    if !activeProjects.isEmpty {
+                        Text("Active Projects")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal)
+                            .padding(.top, 8)
+
+                        ForEach(activeProjects) { project in
+                            optionRow(
+                                icon: "star.fill",
+                                title: project.name,
+                                subtitle: "\(project.threadCount) threads",
+                                isSelected: selection == .existing(project.id)
+                            ) {
+                                selection = .existing(project.id)
+                            }
+                        }
+                    }
+
+                    if !parkedProjects.isEmpty {
+                        Text("Parked Projects")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal)
+                            .padding(.top, 8)
+
+                        ForEach(parkedProjects.prefix(5)) { project in
+                            optionRow(
+                                icon: "moon.zzz",
+                                title: project.name,
+                                subtitle: "\(project.threadCount) threads",
+                                isSelected: selection == .existing(project.id)
+                            ) {
+                                selection = .existing(project.id)
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical)
+            }
+
+            Divider()
+
+            // Actions
+            HStack {
+                Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.escape)
+
+                Spacer()
+
+                Button("Start Conversation") {
+                    startConversation()
+                }
+                .keyboardShortcut(.return)
+                .buttonStyle(.borderedProminent)
+                .disabled(!canStart)
+            }
+            .padding()
+        }
+        .frame(width: 400, height: 500)
+        .task {
+            await loadProjects()
+        }
+    }
+
+    private func optionRow(
+        icon: String,
+        title: String,
+        subtitle: String,
+        isSelected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(isSelected ? .accentColor : .secondary)
+
+                Image(systemName: icon)
+                    .foregroundColor(.secondary)
+                    .frame(width: 20)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.body)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+            .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+            .cornerRadius(8)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var canStart: Bool {
+        switch selection {
+        case .scratchPad, .existing:
+            return true
+        case .new:
+            return !newProjectName.trimmingCharacters(in: .whitespaces).isEmpty
+        }
+    }
+
+    private func loadProjects() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            activeProjects = try await projectService.getActiveProjects()
+            parkedProjects = try await projectService.getParkedProjects()
+            scratchPad = try await projectService.getScratchPad()
+        } catch {
+            #if DEBUG
+            print("[StartConversationSheet] Error: \(error)")
+            #endif
+        }
+    }
+
+    private func startConversation() {
+        switch selection {
+        case .scratchPad:
+            if let pad = scratchPad {
+                onStart(pad.id, nil)
+            }
+        case .existing(let projectId):
+            onStart(projectId, nil)
+        case .new:
+            onStart(-1, newProjectName)  // -1 signals create new
+        }
+    }
+}
+```
+
+**Step 2: Build to verify**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add SeleneChat/Sources/Views/Planning/StartConversationSheet.swift
+git commit -m "feat(view): add StartConversationSheet for project picker"
+```
+
+---
+
+## Task 8: Update ProjectDetailView to Show Threads
+
+**Files:**
+- Modify: `SeleneChat/Sources/Views/ProjectDetailView.swift`
+
+**Step 1: Read current file to understand structure**
+
+**Step 2: Add thread list section**
+
+After the existing content sections, add a ThreadListView:
+
+```swift
+// Add to the body, after attached notes section:
+
+// Threads section
+VStack(alignment: .leading, spacing: 0) {
+    HStack {
+        Image(systemName: "bubble.left.and.bubble.right")
+            .foregroundColor(.blue)
+        Text("Threads")
+            .font(.headline)
+        Text("(\(project.threadCount))")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        Spacer()
+        Button(action: { showNewThreadSheet = true }) {
+            Image(systemName: "plus")
+        }
+        .buttonStyle(.plain)
+    }
+    .padding()
+
+    Divider()
+
+    ThreadListView(projectId: project.id) { thread in
+        selectedThread = thread
+    }
+}
+```
+
+**Step 3: Add state variables for thread selection**
+
+```swift
+@State private var selectedThread: DiscussionThread?
+@State private var showNewThreadSheet = false
+```
+
+**Step 4: Build to verify**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 5: Commit**
+
+```bash
+git add SeleneChat/Sources/Views/ProjectDetailView.swift
+git commit -m "feat(view): add thread list to ProjectDetailView"
+```
+
+---
+
+## Task 9: Update PlanningView Section Order
+
+**Files:**
+- Modify: `SeleneChat/Sources/Views/PlanningView.swift`
+
+**Step 1: Remove needsReviewSection and planningThreadsSection**
+
+These sections become badges on projects instead.
+
+**Step 2: Add Scratch Pad section**
+
+Add state:
+```swift
+@State private var scratchPad: Project?
+@State private var isScratchPadExpanded = true
+```
+
+Add section between Active Projects and Suggestions:
+```swift
+// Scratch Pad section (only if has threads)
+if let pad = scratchPad, pad.threadCount > 0 {
+    scratchPadSection
+        .id("scratchPad")
+}
+```
+
+**Step 3: Reorder sections in ScrollView**
+
+New order:
+1. activeProjectsSection
+2. scratchPadSection (if populated)
+3. suggestionsSection
+4. inboxSection
+5. parkedProjectsSection
+
+**Step 4: Add review badge to project rows**
+
+In ActiveProjectsList, show badge when `project.hasReviewBadge == true`.
+
+**Step 5: Build to verify**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 6: Commit**
+
+```bash
+git add SeleneChat/Sources/Views/PlanningView.swift
+git commit -m "feat(view): reorder Planning tab sections, add Scratch Pad"
+```
+
+---
+
+## Task 10: Update ActiveProjectsList for Review Badges
+
+**Files:**
+- Modify: `SeleneChat/Sources/Views/Planning/ActiveProjectsList.swift`
+
+**Step 1: Add review badge indicator to project row**
+
+After the project name, add:
+
+```swift
+if project.hasReviewBadge {
+    Image(systemName: "bell.badge.fill")
+        .foregroundColor(.orange)
+        .font(.caption)
+}
+```
+
+**Step 2: Show thread count instead of/alongside note count**
+
+```swift
+Text("\(project.threadCount) threads • \(project.noteCount) notes")
+    .font(.caption)
+    .foregroundColor(.secondary)
+```
+
+**Step 3: Build to verify**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add SeleneChat/Sources/Views/Planning/ActiveProjectsList.swift
+git commit -m "feat(view): add review badge and thread count to project rows"
+```
+
+---
+
+## Task 11: Update Sidebar Navigation
+
+**Files:**
+- Modify: `SeleneChat/Sources/Views/PlanningView.swift` (sectionSidebar)
+
+**Step 1: Update sidebar order**
+
+Reorder sidebar buttons to match new section order:
+1. Active Projects
+2. Scratch Pad (if visible)
+3. Suggestions
+4. Inbox
+5. Parked
+
+**Step 2: Remove Conversations and Needs Review buttons**
+
+These are now integrated into projects.
+
+**Step 3: Build to verify**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add SeleneChat/Sources/Views/PlanningView.swift
+git commit -m "feat(view): update sidebar navigation order"
+```
+
+---
+
+## Task 12: Final Build and Test
+
+**Step 1: Full build**
+
+Run: `cd SeleneChat && swift build`
+Expected: Build succeeds with no errors
+
+**Step 2: Update BRANCH-STATUS.md**
+
+Mark development tasks complete.
+
+**Step 3: Commit**
+
+```bash
+git add BRANCH-STATUS.md
+git commit -m "chore: update BRANCH-STATUS.md - development complete"
+```
+
+---
+
+## Summary
+
+| Task | Description | Files |
+|------|-------------|-------|
+| 1 | Database migration | Migration005_ProjectThreads.swift |
+| 2 | Update DiscussionThread model | DiscussionThread.swift |
+| 3 | Update Project model | Project.swift |
+| 4 | Add thread CRUD to DatabaseService | DatabaseService.swift |
+| 5 | Update ProjectService | ProjectService.swift |
+| 6 | Create ThreadListView | ThreadListView.swift |
+| 7 | Create StartConversationSheet | StartConversationSheet.swift |
+| 8 | Update ProjectDetailView | ProjectDetailView.swift |
+| 9 | Update PlanningView sections | PlanningView.swift |
+| 10 | Update ActiveProjectsList | ActiveProjectsList.swift |
+| 11 | Update sidebar navigation | PlanningView.swift |
+| 12 | Final build and test | BRANCH-STATUS.md |
+
+**Estimated commits:** 12
+**Key principle:** Each task is one logical change with a commit.

--- a/docs/plans/2026-01-03-planning-tab-redesign.md
+++ b/docs/plans/2026-01-03-planning-tab-redesign.md
@@ -31,6 +31,9 @@ Planning Tab
 ⭐ Active Projects (2)        ← TOP: Current focus
    [Projects with review badges inline]
 
+📝 Scratch Pad (1)            ← Only shows if populated
+   [Loose threads not yet in a project]
+
 💡 Suggestions (1)            ← Grouping proposals
    [Smart groupings to approve]
 
@@ -44,6 +47,7 @@ Planning Tab
 ### Why This Order
 
 - **Active Projects first:** What you're working on should be immediately visible
+- **Scratch Pad second (when visible):** Loose threads need a home — reminds you to organize
 - **Suggestions before Inbox:** Grouping proposals help you triage faster
 - **Inbox second-to-last:** Important but not the primary focus
 - **Parked last:** Out of sight, prevents overwhelm
@@ -347,11 +351,13 @@ ALTER TABLE task_links ADD COLUMN things_heading TEXT;
 
 ---
 
-## Open Questions
+## Resolved Questions
 
-1. **Thread naming:** Should Selene auto-name threads based on conversation, or require user input?
-2. **Thread limits:** Should projects have a max thread count to prevent sprawl?
-3. **Scratch Pad visibility:** Should it appear in Active Projects or be a special section?
+1. **Thread naming:** Auto-name from first message. User can rename later if needed. Lowest friction.
+
+2. **Thread limits:** No limit. Let projects grow organically. User can archive/merge threads manually if it gets messy.
+
+3. **Scratch Pad visibility:** Hidden until it has items. Keeps UI clean when you're organized. Appears between Active Projects and Suggestions only when populated.
 
 ---
 

--- a/docs/plans/2026-01-03-planning-tab-redesign.md
+++ b/docs/plans/2026-01-03-planning-tab-redesign.md
@@ -1,0 +1,359 @@
+# Planning Tab Redesign
+
+**Status:** Design Complete
+**Created:** 2026-01-03
+**Author:** Chase Easterling + Claude
+**Supersedes:** Section ordering from `2026-01-02-planning-inbox-redesign.md`
+
+---
+
+## Executive Summary
+
+This design restructures the Planning tab to put **Active Projects first** and consolidate conversations **inside projects** rather than as separate entities. Key insight: conversations and projects were treated as separate things, causing fragmentation where Selene suggested multiple projects that were really aspects of the same thing.
+
+### Core Principles
+
+1. **Projects contain threads** — No standalone conversations
+2. **Smart grouping with confirmation** — Selene suggests, user approves
+3. **One project = one Things project** — Threads become headings
+4. **Active first, Inbox second-to-last** — Focus on what you're working on
+
+---
+
+## Planning Tab Structure
+
+### Section Order
+
+```
+Planning Tab
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+⭐ Active Projects (2)        ← TOP: Current focus
+   [Projects with review badges inline]
+
+💡 Suggestions (1)            ← Grouping proposals
+   [Smart groupings to approve]
+
+📥 Inbox (4)                  ← Notes awaiting triage
+   [New notes to process]
+
+🅿️ Parked (8)                 ← BOTTOM: Out of sight
+   [Collapsed by default]
+```
+
+### Why This Order
+
+- **Active Projects first:** What you're working on should be immediately visible
+- **Suggestions before Inbox:** Grouping proposals help you triage faster
+- **Inbox second-to-last:** Important but not the primary focus
+- **Parked last:** Out of sight, prevents overwhelm
+
+---
+
+## Project Structure
+
+### Projects Contain Sub-Topic Threads
+
+A project like "Website Redesign" contains focused threads for different aspects:
+
+```
+Website Redesign
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📎 5 notes attached
+
+Threads:
+┌────────────────────────────────┐
+│ 🎨 Design & Branding           │
+│    2 notes • 1 task • active   │
+└────────────────────────────────┘
+┌────────────────────────────────┐
+│ ⚙️ Tech Stack                  │
+│    2 notes • 2 tasks • paused  │
+└────────────────────────────────┘
+┌────────────────────────────────┐
+│ 📝 Content Migration           │
+│    1 note • no tasks yet       │
+└────────────────────────────────┘
+
+[+ New thread]
+```
+
+### Thread Characteristics
+
+- Each thread has its own focused conversation
+- Threads can be active, paused, or completed
+- Notes attach to threads (or just to the project generally)
+- Tasks created in a thread go to Things under that thread's heading
+
+---
+
+## Smart Grouping
+
+### How It Works
+
+When notes come in that relate to the same concept:
+
+1. Selene detects conceptual similarity
+2. Shows suggestion in Suggestions section
+3. User confirms or corrects
+
+```
+💡 Suggestions
+┌────────────────────────────────────────────┐
+│ 3 notes seem related to "Website Redesign" │
+│                                            │
+│ • "Research Astro for blog"                │
+│ • "Vercel seems good for hosting"          │
+│ • "Color palette ideas"                    │
+│                                            │
+│ [Add to Project]  [Create New]  [Dismiss]  │
+└────────────────────────────────────────────┘
+```
+
+### User Actions
+
+| Action | Result |
+|--------|--------|
+| **Add to Project** | Attaches notes to suggested project |
+| **Create New** | Creates new project from these notes |
+| **Dismiss** | Notes stay in Inbox for manual triage |
+
+---
+
+## Things Integration
+
+### Mapping Model
+
+| SeleneChat | Things |
+|------------|--------|
+| Project | Project |
+| Thread | Heading |
+| Task | Task (under heading) |
+
+### Example
+
+SeleneChat:
+```
+Website Redesign (project)
+├── Tech Stack (thread)
+│   └── "Research Astro vs Next.js" (task)
+└── Design (thread)
+    └── "Pick color palette" (task)
+```
+
+Things:
+```
+Website Redesign (project)
+├── Tech Stack (heading)
+│   └── Research Astro vs Next.js
+└── Design (heading)
+    └── Pick color palette
+```
+
+### Task Creation Flow
+
+1. Conversation in thread extracts task
+2. User confirms task text
+3. Task created in Things under matching heading
+4. If heading doesn't exist, Things creates it
+5. `task_links` table stores relationship
+
+---
+
+## No Standalone Conversations
+
+### The Rule
+
+Every conversation must belong to a project. No orphan threads.
+
+### Starting a Conversation
+
+When tapping "Discuss" on an Inbox note:
+
+```
+┌────────────────────────────────────────┐
+│ Start a conversation about this note   │
+│                                        │
+│ ○ Create new project                   │
+│   [Website Redesign____________]       │
+│                                        │
+│ ○ Add to existing project              │
+│   • Career Planning                    │
+│   • Home Office Setup                  │
+│                                        │
+│ ○ Quick thought (no project)           │
+│   Goes to "Scratch Pad"                │
+│                                        │
+│         [Cancel]  [Start]              │
+└────────────────────────────────────────┘
+```
+
+### Scratch Pad Project
+
+- Default catch-all for loose threads
+- System-created, always exists
+- User can drag threads from Scratch Pad into real projects
+- Prevents orphan conversations while allowing quick capture
+
+---
+
+## Resurface Triggers (Review Badges)
+
+### No Separate Section
+
+Instead of a "Needs Review" section, resurface alerts appear as badges on projects:
+
+```
+⭐ Active Projects (2)
+┌────────────────────────────────┐
+│ Website Redesign        🔔 1   │  ← Badge shows attention needed
+│ 3 threads • 5 tasks            │
+└────────────────────────────────┘
+```
+
+### Inside the Project
+
+The triggering thread is highlighted:
+
+```
+Website Redesign
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Threads:
+┌────────────────────────────────┐
+│ ⚙️ Tech Stack           🔔     │
+│ "All tasks done! Ready to      │
+│  reflect or plan next steps?"  │
+└────────────────────────────────┘
+```
+
+### Trigger Types (unchanged)
+
+| Trigger | Condition | Message |
+|---------|-----------|---------|
+| Progress | 50% tasks done | "Good progress! Ready to plan next steps?" |
+| Stuck | 3 days inactive | "This seems stuck. Want to rethink?" |
+| Completion | 100% tasks done | "All done! Reflect or plan what's next?" |
+
+---
+
+## UI Changes Required
+
+### PlanningView.swift
+
+Current section order:
+1. Needs Review
+2. Suggestions
+3. Inbox
+4. Planning Conversations
+5. Active Projects
+6. Parked Projects
+
+New section order:
+1. Active Projects (with review badges)
+2. Suggestions
+3. Inbox
+4. Parked Projects
+
+Remove:
+- Standalone "Needs Review" section
+- Standalone "Planning Conversations" section
+
+### ProjectDetailView.swift
+
+Add:
+- Thread list inside project
+- Thread creation flow
+- Review badge display on threads
+
+### New Components
+
+| Component | Purpose |
+|-----------|---------|
+| `ThreadListView` | Shows threads inside a project |
+| `ThreadRow` | Single thread with status, note count |
+| `StartConversationSheet` | Project picker when starting discussion |
+| `ScratchPadProject` | System default project for loose threads |
+
+---
+
+## Database Changes
+
+### Modify: discussion_threads
+
+```sql
+-- Threads must belong to a project
+ALTER TABLE discussion_threads ADD COLUMN project_id INTEGER NOT NULL;
+ALTER TABLE discussion_threads ADD COLUMN thread_name TEXT;
+
+-- Foreign key to projects
+FOREIGN KEY (project_id) REFERENCES projects(id)
+```
+
+### New: scratch_pad handling
+
+```sql
+-- System creates default Scratch Pad project on first launch
+INSERT INTO projects (id, name, status, is_system)
+VALUES (0, 'Scratch Pad', 'active', 1);
+```
+
+### Modify: task_links
+
+```sql
+-- Add heading name for Things integration
+ALTER TABLE task_links ADD COLUMN things_heading TEXT;
+```
+
+---
+
+## Migration Path
+
+### Existing Data
+
+1. **Standalone threads** → Move to Scratch Pad project
+2. **Existing projects** → Keep as-is, threads attach to them
+3. **Resurfaced threads** → Convert to badge on parent project
+
+### Code Changes
+
+1. Remove `planningThreadsSection` from PlanningView
+2. Remove `needsReviewSection` from PlanningView
+3. Reorder remaining sections
+4. Add thread list to ProjectDetailView
+5. Add review badge to project rows
+6. Add "Start conversation" project picker sheet
+
+---
+
+## Success Criteria
+
+- [ ] Active Projects appears at top of Planning tab
+- [ ] Inbox appears second-to-last
+- [ ] Projects show sub-topic threads when opened
+- [ ] No standalone conversations exist
+- [ ] Scratch Pad catches loose threads
+- [ ] Review badges appear on projects (not separate section)
+- [ ] Smart grouping suggestions work with confirmation
+- [ ] Tasks go to Things with correct heading
+
+---
+
+## Related Documents
+
+- [Planning Inbox Redesign](./2026-01-02-planning-inbox-redesign.md) — Triage UX (still applies)
+- [Phase 7.2 SeleneChat Planning](./2025-12-31-phase-7.2-selenechat-planning-design.md) — Original design
+- [Project Grouping Design](./2026-01-01-project-grouping-design.md) — Auto-grouping logic
+
+---
+
+## Open Questions
+
+1. **Thread naming:** Should Selene auto-name threads based on conversation, or require user input?
+2. **Thread limits:** Should projects have a max thread count to prevent sprawl?
+3. **Scratch Pad visibility:** Should it appear in Active Projects or be a special section?
+
+---
+
+**Document Status:** Design Complete
+**Next Step:** Implementation planning with superpowers:writing-plans

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -1,6 +1,6 @@
 # Design Documents Index
 
-**Last Updated:** 2026-01-02
+**Last Updated:** 2026-01-03
 
 Status legend:
 - **Active** - Ready for implementation or in progress
@@ -13,6 +13,7 @@ Status legend:
 
 | Date | Document | Phase | Notes |
 |------|----------|-------|-------|
+| 2026-01-03 | planning-tab-redesign.md | 7.2 | Projects contain threads, Active first, no standalone conversations |
 | 2026-01-02 | bidirectional-things-flow-design.md | 7.2e | Things status sync + resurface triggers |
 | 2026-01-01 | project-grouping-design.md | 7.2f | Things project grouping |
 | 2026-01-01 | n8n-upgrade-design.md | infra | n8n 1.x to 2.x upgrade |


### PR DESCRIPTION
## Summary

Restructures the Planning tab in SeleneChat so that projects contain threads (sub-topic conversations), with a new section order designed for ADHD-optimized workflows:

- **Section reorder**: Active Projects → Scratch Pad → Suggestions → Inbox → Parked
- **Projects contain threads**: Each project can have multiple focused conversation threads
- **Scratch Pad**: System project as catch-all for loose thoughts (hidden until populated)
- **Review badges**: Shown on projects instead of separate section
- **Thread auto-naming**: From first message content

## Changes

### Database
- Migration005: Adds `project_id`, `thread_name` to `discussion_threads`; `is_system` to `projects`
- Creates system Scratch Pad project, migrates orphan threads

### Models
- `DiscussionThread`: Added `projectId`, `threadName`
- `Project`: Added `isSystem`, `threadCount`, `hasReviewBadge`

### Services
- `DatabaseService`: Thread CRUD operations, Scratch Pad queries
- `ProjectService`: Thread count, review badge, getScratchPad()

### Views
- **New**: `ThreadListView`, `StartConversationSheet`
- **Updated**: `PlanningView` (section order), `ProjectDetailView` (thread list), `ActiveProjectsList` (badges/counts)

## Test Plan
- [x] Build passes (`swift build`)
- [ ] Manual testing: Create threads, verify section order
- [ ] Manual testing: Scratch Pad behavior when empty/populated
- [ ] Manual testing: Review badge display on projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)