### PR TITLE
feat(selenechat): Thread Workspace with scoped chat and task creation

### DIFF
--- a/SeleneChat/Sources/App/ContentView.swift
+++ b/SeleneChat/Sources/App/ContentView.swift
@@ -4,6 +4,7 @@ struct ContentView: View {
     @State private var selectedView: NavigationItem = .today
     @State private var pendingThreadQuery: String?
     @State private var showBriefing = true  // Show briefing on app open
+    @State private var selectedThreadId: Int64?  // For thread workspace navigation
     @EnvironmentObject var databaseService: DatabaseService
 
     enum NavigationItem: String, CaseIterable {
@@ -31,7 +32,21 @@ struct ContentView: View {
             .navigationTitle("Selene")
             .frame(minWidth: 200)
         } detail: {
-            if showBriefing {
+            if let threadId = selectedThreadId {
+                // Thread Workspace view
+                ThreadWorkspaceView(threadId: threadId)
+                    .environmentObject(databaseService)
+                    .onDisappear {
+                        // Clear when navigating away (though sheet dismissal handles this too)
+                    }
+                    .toolbar {
+                        ToolbarItem(placement: .navigation) {
+                            Button(action: { selectedThreadId = nil }) {
+                                Image(systemName: "xmark")
+                            }
+                        }
+                    }
+            } else if showBriefing {
                 BriefingView(
                     onDismiss: {
                         showBriefing = false
@@ -47,13 +62,13 @@ struct ContentView: View {
                 case .today:
                     TodayView(
                         onThreadSelected: { thread in
-                            pendingThreadQuery = "show me \(thread.name) thread"
-                            selectedView = .chat
+                            // Navigate to Thread Workspace
+                            selectedThreadId = thread.id
                         },
                         onNoteThreadTap: { note in
-                            if let threadName = note.threadName {
-                                pendingThreadQuery = "What's happening with \(threadName)?"
-                                selectedView = .chat
+                            if let threadId = note.threadId {
+                                // Navigate to Thread Workspace
+                                selectedThreadId = threadId
                             }
                         }
                     )

--- a/SeleneChat/Sources/Models/ThreadTask.swift
+++ b/SeleneChat/Sources/Models/ThreadTask.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// A task linked to a semantic thread
+struct ThreadTask: Identifiable, Hashable {
+    let id: Int64
+    let threadId: Int64
+    let thingsTaskId: String
+    let createdAt: Date
+    let completedAt: Date?
+
+    /// Title fetched from Things (not stored in Selene)
+    var title: String?
+
+    /// Whether the task is completed
+    var isCompleted: Bool {
+        completedAt != nil
+    }
+
+    var completedDisplay: String {
+        guard let date = completedAt else { return "" }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return "Done \(formatter.localizedString(for: date, relativeTo: Date()))"
+    }
+}
+
+#if DEBUG
+extension ThreadTask {
+    static func mock(
+        id: Int64 = 1,
+        threadId: Int64 = 1,
+        thingsTaskId: String = "ABC123",
+        title: String? = "Sample Task",
+        createdAt: Date = Date(),
+        completedAt: Date? = nil
+    ) -> ThreadTask {
+        var task = ThreadTask(
+            id: id,
+            threadId: threadId,
+            thingsTaskId: thingsTaskId,
+            createdAt: createdAt,
+            completedAt: completedAt
+        )
+        task.title = title
+        return task
+    }
+}
+#endif

--- a/SeleneChat/Sources/Services/Migrations/Migration009_ThreadTasks.swift
+++ b/SeleneChat/Sources/Services/Migrations/Migration009_ThreadTasks.swift
@@ -1,0 +1,32 @@
+// Migration009_ThreadTasks.swift
+// SeleneChat
+//
+// Links Things tasks to semantic threads for workspace view
+
+import Foundation
+import SQLite
+
+struct Migration009_ThreadTasks {
+    static func run(db: Connection) throws {
+        // Create thread_tasks table
+        try db.run("""
+            CREATE TABLE IF NOT EXISTS thread_tasks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                thread_id INTEGER NOT NULL,
+                things_task_id TEXT NOT NULL,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                completed_at TEXT,
+                FOREIGN KEY (thread_id) REFERENCES threads(id) ON DELETE CASCADE,
+                UNIQUE(thread_id, things_task_id)
+            )
+        """)
+
+        // Index for querying tasks by thread
+        try db.run("CREATE INDEX IF NOT EXISTS idx_thread_tasks_thread ON thread_tasks(thread_id)")
+
+        // Index for looking up thread by Things task ID (for sync)
+        try db.run("CREATE INDEX IF NOT EXISTS idx_thread_tasks_things ON thread_tasks(things_task_id)")
+
+        print("Migration 009: thread_tasks table created")
+    }
+}

--- a/SeleneChat/Sources/Services/ThreadWorkspacePromptBuilder.swift
+++ b/SeleneChat/Sources/Services/ThreadWorkspacePromptBuilder.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Builds prompts for thread workspace chat conversations.
+/// Similar to DeepDivePromptBuilder but includes task state context.
+class ThreadWorkspacePromptBuilder {
+
+    private let contextBuilder = ThinkingPartnerContextBuilder()
+
+    // MARK: - Action Marker Format
+
+    private let actionMarkerFormat = """
+    When suggesting actions, use this format:
+    [ACTION: Brief action description | ENERGY: high/medium/low | TIMEFRAME: today/this-week/someday]
+    """
+
+    // MARK: - Initial Prompt
+
+    /// Build the initial prompt for a workspace chat session.
+    /// - Parameters:
+    ///   - thread: The thread being worked on
+    ///   - notes: Notes belonging to this thread
+    ///   - tasks: Current tasks linked to this thread
+    /// - Returns: A formatted prompt string for the LLM
+    func buildInitialPrompt(thread: Thread, notes: [Note], tasks: [ThreadTask]) -> String {
+        let threadContext = contextBuilder.buildDeepDiveContext(thread: thread, notes: notes)
+        let taskContext = buildTaskContext(tasks)
+
+        return """
+        You are a thinking partner for someone with ADHD, helping them plan and break down work for "\(thread.name)".
+
+        \(threadContext)
+
+        \(taskContext)
+
+        Your task:
+        1. Understand what's already been explored in the notes
+        2. Consider what tasks already exist and what gaps remain
+        3. Help break down next steps into concrete, actionable tasks
+        4. Ask 1-2 clarifying questions if the direction isn't clear
+
+        \(actionMarkerFormat)
+
+        Keep your response under 200 words. Focus on actionable next steps, not summary.
+        """
+    }
+
+    // MARK: - Follow-Up Prompt
+
+    /// Build a follow-up prompt that includes conversation history and current task state.
+    /// - Parameters:
+    ///   - thread: The thread being worked on
+    ///   - notes: Notes belonging to this thread
+    ///   - tasks: Current tasks linked to this thread
+    ///   - conversationHistory: Previous exchanges in this session
+    ///   - currentQuery: The user's current question
+    /// - Returns: A formatted prompt string for the LLM
+    func buildFollowUpPrompt(
+        thread: Thread,
+        notes: [Note],
+        tasks: [ThreadTask],
+        conversationHistory: String,
+        currentQuery: String
+    ) -> String {
+        let threadContext = contextBuilder.buildDeepDiveContext(thread: thread, notes: notes)
+        let taskContext = buildTaskContext(tasks)
+
+        return """
+        You are a thinking partner for someone with ADHD, continuing a planning session for "\(thread.name)".
+
+        \(threadContext)
+
+        \(taskContext)
+
+        ## Conversation So Far
+        \(conversationHistory)
+
+        ## Current Question
+        \(currentQuery)
+
+        \(actionMarkerFormat)
+
+        Keep your response under 150 words. Be direct and specific.
+        """
+    }
+
+    // MARK: - Task Context
+
+    private func buildTaskContext(_ tasks: [ThreadTask]) -> String {
+        guard !tasks.isEmpty else {
+            return "## Current Tasks\nNo tasks linked to this thread yet."
+        }
+
+        let openTasks = tasks.filter { !$0.isCompleted }
+        let completedTasks = tasks.filter { $0.isCompleted }
+
+        var context = "## Current Tasks (\(openTasks.count) open, \(completedTasks.count) completed)\n"
+
+        for task in openTasks {
+            let title = task.title ?? task.thingsTaskId
+            context += "- [ ] \(title)\n"
+        }
+
+        for task in completedTasks {
+            let title = task.title ?? task.thingsTaskId
+            context += "- [x] \(title)\n"
+        }
+
+        return context
+    }
+}

--- a/SeleneChat/Sources/ViewModels/ThreadWorkspaceChatViewModel.swift
+++ b/SeleneChat/Sources/ViewModels/ThreadWorkspaceChatViewModel.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+/// Chat view model scoped to a single thread workspace.
+/// Handles message pipeline, action extraction, and confirmation flow.
+@MainActor
+class ThreadWorkspaceChatViewModel: ObservableObject {
+
+    // MARK: - Published State
+
+    @Published var messages: [Message] = []
+    @Published var isProcessing = false
+    @Published var pendingActions: [ActionExtractor.ExtractedAction] = []
+
+    // MARK: - Context
+
+    let thread: Thread
+    let notes: [Note]
+    private(set) var tasks: [ThreadTask]
+
+    // MARK: - Services
+
+    private let ollamaService = OllamaService.shared
+    private let actionExtractor = ActionExtractor()
+    private let actionService = ActionService()
+    private let promptBuilder = ThreadWorkspacePromptBuilder()
+    private let databaseService = DatabaseService.shared
+
+    // MARK: - Init
+
+    init(thread: Thread, notes: [Note], tasks: [ThreadTask]) {
+        self.thread = thread
+        self.notes = notes
+        self.tasks = tasks
+    }
+
+    // MARK: - Send Message
+
+    /// Send a user message and get an LLM response.
+    func sendMessage(_ content: String) async {
+        guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+
+        addUserMessage(content)
+        isProcessing = true
+        defer { isProcessing = false }
+
+        do {
+            let prompt = buildPrompt(for: content)
+            let response = try await ollamaService.generate(prompt: prompt)
+            processResponse(response)
+        } catch {
+            let errorMessage = Message(
+                role: .assistant,
+                content: "Sorry, I couldn't process that. \(error.localizedDescription)",
+                llmTier: .local
+            )
+            messages.append(errorMessage)
+        }
+    }
+
+    // MARK: - Process Response
+
+    /// Process an LLM response: extract actions and add cleaned message.
+    func processResponse(_ response: String) {
+        let actions = actionExtractor.extractActions(from: response)
+        let cleanedResponse = actionExtractor.removeActionMarkers(from: response)
+
+        let message = Message(
+            role: .assistant,
+            content: cleanedResponse,
+            llmTier: .local
+        )
+        messages.append(message)
+
+        // Replace any previous pending actions with new ones
+        pendingActions = actions
+    }
+
+    // MARK: - User Message
+
+    /// Add a user message to the conversation.
+    func addUserMessage(_ content: String) {
+        let message = Message(
+            role: .user,
+            content: content,
+            llmTier: .local
+        )
+        messages.append(message)
+    }
+
+    // MARK: - Action Confirmation
+
+    /// Confirm pending actions: create tasks in Things and link to thread.
+    func confirmActions() async -> [String] {
+        var createdIds: [String] = []
+
+        for action in pendingActions {
+            do {
+                let thingsId = try await actionService.sendToThingsAndLinkThread(
+                    action,
+                    threadName: thread.name,
+                    threadId: thread.id
+                )
+                createdIds.append(thingsId)
+            } catch {
+                print("[ThreadWorkspaceChatVM] Failed to create task: \(error)")
+            }
+        }
+
+        pendingActions = []
+
+        // Reload tasks to reflect newly created ones
+        if !createdIds.isEmpty {
+            do {
+                tasks = try await databaseService.getTasksForThread(thread.id)
+            } catch {
+                print("[ThreadWorkspaceChatVM] Failed to reload tasks: \(error)")
+            }
+        }
+
+        return createdIds
+    }
+
+    /// Dismiss pending actions without creating tasks.
+    func dismissActions() {
+        pendingActions = []
+    }
+
+    // MARK: - Update Tasks
+
+    /// Update the task list (e.g., after external changes).
+    func updateTasks(_ newTasks: [ThreadTask]) {
+        tasks = newTasks
+    }
+
+    // MARK: - Prompt Building
+
+    /// Build the appropriate prompt for the current conversation state.
+    func buildPrompt(for query: String) -> String {
+        // If no prior conversation, use initial prompt
+        let priorMessages = messages.filter { $0.role != .system }
+        // Only user+assistant messages before the current user message count as history
+        // The current user message was just added, so check for prior assistant messages
+        let hasHistory = priorMessages.contains { $0.role == .assistant }
+
+        if hasHistory {
+            let history = buildConversationHistory()
+            return promptBuilder.buildFollowUpPrompt(
+                thread: thread,
+                notes: notes,
+                tasks: tasks,
+                conversationHistory: history,
+                currentQuery: query
+            )
+        } else {
+            return promptBuilder.buildInitialPrompt(
+                thread: thread,
+                notes: notes,
+                tasks: tasks
+            )
+        }
+    }
+
+    /// Build conversation history string from messages.
+    func buildConversationHistory() -> String {
+        messages.map { msg in
+            let role = msg.role == .user ? "User" : "Assistant"
+            return "\(role): \(msg.content)"
+        }.joined(separator: "\n")
+    }
+}

--- a/SeleneChat/Sources/Views/ThreadWorkspaceView.swift
+++ b/SeleneChat/Sources/Views/ThreadWorkspaceView.swift
@@ -1,0 +1,384 @@
+// ThreadWorkspaceView.swift
+// SeleneChat
+//
+// Thread Workspace: See a thread with its context, tasks, and notes in one view.
+// Phase 1: Read-only view (no chat yet)
+
+import SwiftUI
+
+struct ThreadWorkspaceView: View {
+    let threadId: Int64
+
+    @EnvironmentObject var databaseService: DatabaseService
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var thread: Thread?
+    @State private var tasks: [ThreadTask] = []
+    @State private var notes: [Note] = []
+    @State private var isLoading = true
+    @State private var error: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            headerView
+
+            Divider()
+
+            if isLoading {
+                loadingView
+            } else if let error = error {
+                errorView(error)
+            } else if let thread = thread {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        // Thread context
+                        threadContextSection(thread)
+
+                        // Tasks section
+                        tasksSection
+
+                        // Notes section
+                        notesSection
+                    }
+                    .padding()
+                }
+            }
+        }
+        .frame(minWidth: 500, minHeight: 400)
+        .task {
+            await loadData()
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerView: some View {
+        HStack {
+            Button(action: { dismiss() }) {
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left")
+                    Text("Back")
+                }
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            Text("Thread Workspace")
+                .font(.headline)
+
+            Spacer()
+
+            // Placeholder for future actions
+            Button(action: { Task { await loadData() } }) {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(.plain)
+            .disabled(isLoading)
+        }
+        .padding()
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+
+    // MARK: - Thread Context
+
+    private func threadContextSection(_ thread: Thread) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Name and status
+            HStack {
+                Text(thread.statusEmoji)
+                Text(thread.name)
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                Spacer()
+                momentumIndicator(thread.momentumScore)
+            }
+
+            // Why (motivation)
+            if let why = thread.why, !why.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("WHY")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.secondary)
+                    Text(why)
+                        .font(.body)
+                        .foregroundColor(.primary)
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.orange.opacity(0.1))
+                .cornerRadius(8)
+            }
+
+            // Summary
+            if let summary = thread.summary, !summary.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("CURRENT STATE")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.secondary)
+                    Text(summary)
+                        .font(.body)
+                }
+            }
+
+            // Metadata
+            HStack(spacing: 16) {
+                Label("\(thread.noteCount) notes", systemImage: "note.text")
+                Label(thread.lastActivityDisplay, systemImage: "clock")
+            }
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+        .padding()
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(12)
+    }
+
+    private func momentumIndicator(_ score: Double?) -> some View {
+        HStack(spacing: 2) {
+            ForEach(0..<5) { i in
+                Circle()
+                    .fill(i < Int((score ?? 0) * 5) ? Color.orange : Color.gray.opacity(0.3))
+                    .frame(width: 8, height: 8)
+            }
+        }
+    }
+
+    // MARK: - Tasks Section
+
+    private var tasksSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("TASKS")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.secondary)
+
+                Spacer()
+
+                Text("\(tasks.count)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.2))
+                    .cornerRadius(4)
+            }
+
+            if tasks.isEmpty {
+                emptyTasksView
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(tasks) { task in
+                        taskRow(task)
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyTasksView: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "checkmark.circle")
+                .font(.title)
+                .foregroundColor(.secondary)
+            Text("No tasks linked to this thread yet")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Text("Tasks created in chat will appear here")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(8)
+    }
+
+    private func taskRow(_ task: ThreadTask) -> some View {
+        HStack(spacing: 12) {
+            // Completion indicator
+            Image(systemName: task.isCompleted ? "checkmark.circle.fill" : "circle")
+                .foregroundColor(task.isCompleted ? .green : .secondary)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(task.title ?? task.thingsTaskId)
+                    .font(.body)
+                    .strikethrough(task.isCompleted)
+                    .foregroundColor(task.isCompleted ? .secondary : .primary)
+
+                if task.isCompleted {
+                    Text(task.completedDisplay)
+                        .font(.caption)
+                        .foregroundColor(.green)
+                }
+            }
+
+            Spacer()
+
+            // Open in Things button
+            Button(action: { openInThings(task.thingsTaskId) }) {
+                Image(systemName: "arrow.up.right.square")
+                    .foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding()
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(8)
+    }
+
+    // MARK: - Notes Section
+
+    private var notesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("NOTES IN THIS THREAD")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.secondary)
+
+                Spacer()
+
+                Text("\(notes.count)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.2))
+                    .cornerRadius(4)
+            }
+
+            if notes.isEmpty {
+                Text("No notes linked yet")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(Color(NSColor.controlBackgroundColor))
+                    .cornerRadius(8)
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(notes.prefix(5)) { note in
+                        noteRow(note)
+                    }
+                    if notes.count > 5 {
+                        Text("+ \(notes.count - 5) more notes")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.top, 4)
+                    }
+                }
+            }
+        }
+    }
+
+    private func noteRow(_ note: Note) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(note.title)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .lineLimit(1)
+                Spacer()
+                Text(note.relativeDate)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            Text(String(note.content.prefix(100)))
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+        }
+        .padding()
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(8)
+    }
+
+    // MARK: - States
+
+    private var loadingView: some View {
+        VStack {
+            Spacer()
+            ProgressView("Loading thread...")
+            Spacer()
+        }
+    }
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+                .foregroundColor(.orange)
+            Text("Couldn't load thread")
+                .font(.headline)
+            Text(message)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Button("Try Again") {
+                Task { await loadData() }
+            }
+            Spacer()
+        }
+    }
+
+    // MARK: - Data Loading
+
+    private func loadData() async {
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        do {
+            // Load thread details
+            thread = try await databaseService.getThreadById(threadId)
+
+            guard thread != nil else {
+                error = "Thread not found"
+                return
+            }
+
+            // Load tasks for thread
+            tasks = try await databaseService.getTasksForThread(threadId)
+
+            // Load notes for thread
+            if let result = try await databaseService.getThreadByName(thread!.name) {
+                notes = result.1
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    // MARK: - Actions
+
+    private func openInThings(_ taskId: String) {
+        let urlString = "things:///show?id=\(taskId)"
+        if let url = URL(string: urlString) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+
+// MARK: - Note Extension
+
+extension Note {
+    var relativeDate: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: createdAt, relativeTo: Date())
+    }
+}
+
+#if DEBUG
+struct ThreadWorkspaceView_Previews: PreviewProvider {
+    static var previews: some View {
+        ThreadWorkspaceView(threadId: 1)
+            .environmentObject(DatabaseService.shared)
+    }
+}
+#endif

--- a/SeleneChat/Tests/SeleneChatTests/Integration/ThreadWorkspaceIntegrationTests.swift
+++ b/SeleneChat/Tests/SeleneChatTests/Integration/ThreadWorkspaceIntegrationTests.swift
@@ -1,0 +1,286 @@
+import XCTest
+import SQLite
+@testable import SeleneChat
+
+final class ThreadWorkspaceIntegrationTests: XCTestCase {
+
+    var databaseService: DatabaseService!
+    var testDatabasePath: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        let tempDir = FileManager.default.temporaryDirectory
+        testDatabasePath = tempDir.appendingPathComponent("test_thread_workspace_\(UUID().uuidString).db").path
+
+        databaseService = DatabaseService()
+        databaseService.databasePath = testDatabasePath
+
+        // Create prerequisite tables not managed by Swift migrations
+        // (threads table is created by TypeScript backend migration 013)
+        guard let db = databaseService.db else {
+            XCTFail("Database not connected")
+            return
+        }
+
+        try db.run("""
+            CREATE TABLE IF NOT EXISTS threads (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                why TEXT,
+                summary TEXT,
+                status TEXT DEFAULT 'active',
+                note_count INTEGER DEFAULT 0,
+                momentum_score REAL,
+                last_activity_at TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        // Ensure thread_tasks table exists (should be created by Migration009)
+        try Migration009_ThreadTasks.run(db: db)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(atPath: testDatabasePath)
+        databaseService = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func insertThread(name: String, why: String? = nil, summary: String? = nil, status: String = "active") throws -> Int64 {
+        guard let db = databaseService.db else {
+            XCTFail("Database not connected")
+            return -1
+        }
+
+        let threadsTable = Table("threads")
+        let nameCol = SQLite.Expression<String>("name")
+        let whyCol = SQLite.Expression<String?>("why")
+        let summaryCol = SQLite.Expression<String?>("summary")
+        let statusCol = SQLite.Expression<String>("status")
+        let noteCountCol = SQLite.Expression<Int64>("note_count")
+
+        try db.run(threadsTable.insert(
+            nameCol <- name,
+            whyCol <- why,
+            summaryCol <- summary,
+            statusCol <- status,
+            noteCountCol <- 0
+        ))
+
+        return db.lastInsertRowid
+    }
+
+    // MARK: - getTasksForThread
+
+    func testGetTasksForThreadReturnsEmptyWhenNoTasks() async throws {
+        let threadId = try insertThread(name: "Empty Thread")
+
+        let tasks = try await databaseService.getTasksForThread(threadId)
+        XCTAssertEqual(tasks.count, 0)
+    }
+
+    func testGetTasksForThreadReturnsTasks() async throws {
+        let threadId = try insertThread(name: "Test Thread")
+
+        // Insert tasks directly
+        try await databaseService.linkTaskToThread(threadId: threadId, thingsTaskId: "THINGS-001")
+        try await databaseService.linkTaskToThread(threadId: threadId, thingsTaskId: "THINGS-002")
+
+        let tasks = try await databaseService.getTasksForThread(threadId)
+        XCTAssertEqual(tasks.count, 2)
+
+        let taskIds = tasks.map { $0.thingsTaskId }
+        XCTAssertTrue(taskIds.contains("THINGS-001"))
+        XCTAssertTrue(taskIds.contains("THINGS-002"))
+    }
+
+    func testGetTasksForThreadReturnsCorrectFields() async throws {
+        let threadId = try insertThread(name: "Test Thread")
+        try await databaseService.linkTaskToThread(threadId: threadId, thingsTaskId: "THINGS-XYZ")
+
+        let tasks = try await databaseService.getTasksForThread(threadId)
+        XCTAssertEqual(tasks.count, 1)
+
+        let task = tasks[0]
+        XCTAssertEqual(task.threadId, threadId)
+        XCTAssertEqual(task.thingsTaskId, "THINGS-XYZ")
+        XCTAssertFalse(task.isCompleted)
+        XCTAssertNil(task.completedAt)
+    }
+
+    func testGetTasksForThreadOnlyReturnsTasksForGivenThread() async throws {
+        let thread1 = try insertThread(name: "Thread 1")
+        let thread2 = try insertThread(name: "Thread 2")
+
+        try await databaseService.linkTaskToThread(threadId: thread1, thingsTaskId: "TASK-A")
+        try await databaseService.linkTaskToThread(threadId: thread2, thingsTaskId: "TASK-B")
+        try await databaseService.linkTaskToThread(threadId: thread1, thingsTaskId: "TASK-C")
+
+        let tasks1 = try await databaseService.getTasksForThread(thread1)
+        XCTAssertEqual(tasks1.count, 2)
+
+        let tasks2 = try await databaseService.getTasksForThread(thread2)
+        XCTAssertEqual(tasks2.count, 1)
+        XCTAssertEqual(tasks2[0].thingsTaskId, "TASK-B")
+    }
+
+    func testGetTasksForThreadOrdersByCreatedAtDescending() async throws {
+        let threadId = try insertThread(name: "Test Thread")
+        guard let db = databaseService.db else {
+            XCTFail("Database not connected")
+            return
+        }
+
+        // Insert with explicit timestamps to guarantee ordering
+        // (CURRENT_TIMESTAMP has second-level precision, too coarse for fast inserts)
+        let threadTasksTable = Table("thread_tasks")
+        let threadIdCol = SQLite.Expression<Int64>("thread_id")
+        let thingsTaskIdCol = SQLite.Expression<String>("things_task_id")
+        let createdAtCol = SQLite.Expression<String>("created_at")
+
+        try db.run(threadTasksTable.insert(
+            threadIdCol <- threadId,
+            thingsTaskIdCol <- "FIRST",
+            createdAtCol <- "2026-02-06 10:00:00"
+        ))
+        try db.run(threadTasksTable.insert(
+            threadIdCol <- threadId,
+            thingsTaskIdCol <- "SECOND",
+            createdAtCol <- "2026-02-06 11:00:00"
+        ))
+
+        let tasks = try await databaseService.getTasksForThread(threadId)
+        XCTAssertEqual(tasks.count, 2)
+        // Most recent first (desc order)
+        XCTAssertEqual(tasks[0].thingsTaskId, "SECOND")
+        XCTAssertEqual(tasks[1].thingsTaskId, "FIRST")
+    }
+
+    // MARK: - linkTaskToThread
+
+    func testLinkTaskToThreadCreatesRecord() async throws {
+        let threadId = try insertThread(name: "Test Thread")
+
+        try await databaseService.linkTaskToThread(threadId: threadId, thingsTaskId: "NEW-TASK")
+
+        let tasks = try await databaseService.getTasksForThread(threadId)
+        XCTAssertEqual(tasks.count, 1)
+        XCTAssertEqual(tasks[0].thingsTaskId, "NEW-TASK")
+    }
+
+    func testLinkTaskToThreadIgnoresDuplicates() async throws {
+        let threadId = try insertThread(name: "Test Thread")
+
+        // Link same task twice (INSERT OR IGNORE)
+        try await databaseService.linkTaskToThread(threadId: threadId, thingsTaskId: "SAME-TASK")
+        try await databaseService.linkTaskToThread(threadId: threadId, thingsTaskId: "SAME-TASK")
+
+        let tasks = try await databaseService.getTasksForThread(threadId)
+        XCTAssertEqual(tasks.count, 1, "Duplicate should be ignored")
+    }
+
+    // MARK: - markThreadTaskCompleted
+
+    func testMarkThreadTaskCompleted() async throws {
+        let threadId = try insertThread(name: "Test Thread")
+        try await databaseService.linkTaskToThread(threadId: threadId, thingsTaskId: "COMPLETE-ME")
+
+        // Verify not completed initially
+        var tasks = try await databaseService.getTasksForThread(threadId)
+        XCTAssertFalse(tasks[0].isCompleted)
+
+        // Mark completed
+        try await databaseService.markThreadTaskCompleted(thingsTaskId: "COMPLETE-ME")
+
+        // Verify completed
+        tasks = try await databaseService.getTasksForThread(threadId)
+        XCTAssertTrue(tasks[0].isCompleted)
+        XCTAssertNotNil(tasks[0].completedAt)
+    }
+
+    func testMarkThreadTaskCompletedWithCustomDate() async throws {
+        let threadId = try insertThread(name: "Test Thread")
+        try await databaseService.linkTaskToThread(threadId: threadId, thingsTaskId: "DATED-TASK")
+
+        let completionDate = Calendar.current.date(byAdding: .hour, value: -2, to: Date())!
+        try await databaseService.markThreadTaskCompleted(thingsTaskId: "DATED-TASK", completedAt: completionDate)
+
+        let tasks = try await databaseService.getTasksForThread(threadId)
+        XCTAssertTrue(tasks[0].isCompleted)
+        XCTAssertNotNil(tasks[0].completedAt)
+
+        // Verify the date is close to what we set (within 1 second tolerance)
+        let timeDiff = abs(tasks[0].completedAt!.timeIntervalSince(completionDate))
+        XCTAssertLessThan(timeDiff, 1.0, "Completion date should match within 1 second")
+    }
+
+    // MARK: - getThreadById
+
+    func testGetThreadByIdReturnsThread() async throws {
+        let threadId = try insertThread(
+            name: "ADHD System Design",
+            why: "Build tools that externalize executive function",
+            summary: "Exploring approaches to reduce cognitive load",
+            status: "active"
+        )
+
+        let thread = try await databaseService.getThreadById(threadId)
+        XCTAssertNotNil(thread)
+        XCTAssertEqual(thread?.name, "ADHD System Design")
+        XCTAssertEqual(thread?.why, "Build tools that externalize executive function")
+        XCTAssertEqual(thread?.summary, "Exploring approaches to reduce cognitive load")
+        XCTAssertEqual(thread?.status, "active")
+    }
+
+    func testGetThreadByIdReturnsNilForInvalidId() async throws {
+        let thread = try await databaseService.getThreadById(999)
+        XCTAssertNil(thread)
+    }
+
+    func testGetThreadByIdHandlesNullOptionalFields() async throws {
+        let threadId = try insertThread(name: "Minimal Thread")
+
+        let thread = try await databaseService.getThreadById(threadId)
+        XCTAssertNotNil(thread)
+        XCTAssertEqual(thread?.name, "Minimal Thread")
+        XCTAssertNil(thread?.why)
+        XCTAssertNil(thread?.summary)
+    }
+
+    // MARK: - End-to-end workspace flow
+
+    func testWorkspaceFlowThreadWithTasks() async throws {
+        // Create a thread
+        let threadId = try insertThread(
+            name: "Voice Input Feature",
+            why: "Reduce friction for quick captures",
+            summary: "Phase 1 complete with push-to-talk"
+        )
+
+        // Link some tasks
+        try await databaseService.linkTaskToThread(threadId: threadId, thingsTaskId: "VOICE-001")
+        try await databaseService.linkTaskToThread(threadId: threadId, thingsTaskId: "VOICE-002")
+        try await databaseService.linkTaskToThread(threadId: threadId, thingsTaskId: "VOICE-003")
+
+        // Complete one
+        try await databaseService.markThreadTaskCompleted(thingsTaskId: "VOICE-002")
+
+        // Load thread
+        let thread = try await databaseService.getThreadById(threadId)
+        XCTAssertNotNil(thread)
+        XCTAssertEqual(thread?.name, "Voice Input Feature")
+
+        // Load tasks
+        let tasks = try await databaseService.getTasksForThread(threadId)
+        XCTAssertEqual(tasks.count, 3)
+
+        let completedTasks = tasks.filter { $0.isCompleted }
+        let openTasks = tasks.filter { !$0.isCompleted }
+        XCTAssertEqual(completedTasks.count, 1)
+        XCTAssertEqual(openTasks.count, 2)
+        XCTAssertEqual(completedTasks[0].thingsTaskId, "VOICE-002")
+    }
+}

--- a/SeleneChat/Tests/SeleneChatTests/Models/ThreadTaskTests.swift
+++ b/SeleneChat/Tests/SeleneChatTests/Models/ThreadTaskTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import SeleneChat
+
+final class ThreadTaskTests: XCTestCase {
+
+    // MARK: - isCompleted
+
+    func testIsCompletedWhenCompletedAtIsNil() {
+        let task = ThreadTask(
+            id: 1,
+            threadId: 1,
+            thingsTaskId: "ABC123",
+            createdAt: Date(),
+            completedAt: nil
+        )
+        XCTAssertFalse(task.isCompleted)
+    }
+
+    func testIsCompletedWhenCompletedAtIsSet() {
+        let task = ThreadTask(
+            id: 1,
+            threadId: 1,
+            thingsTaskId: "ABC123",
+            createdAt: Date(),
+            completedAt: Date()
+        )
+        XCTAssertTrue(task.isCompleted)
+    }
+
+    // MARK: - completedDisplay
+
+    func testCompletedDisplayWhenNotCompleted() {
+        let task = ThreadTask(
+            id: 1,
+            threadId: 1,
+            thingsTaskId: "ABC123",
+            createdAt: Date(),
+            completedAt: nil
+        )
+        XCTAssertEqual(task.completedDisplay, "")
+    }
+
+    func testCompletedDisplayWhenCompleted() {
+        let task = ThreadTask(
+            id: 1,
+            threadId: 1,
+            thingsTaskId: "ABC123",
+            createdAt: Date(),
+            completedAt: Date()
+        )
+        // Should start with "Done" and contain relative time
+        XCTAssertTrue(task.completedDisplay.hasPrefix("Done "))
+    }
+
+    // MARK: - title property
+
+    func testTitleDefaultsToNil() {
+        let task = ThreadTask(
+            id: 1,
+            threadId: 1,
+            thingsTaskId: "ABC123",
+            createdAt: Date(),
+            completedAt: nil
+        )
+        XCTAssertNil(task.title)
+    }
+
+    func testTitleCanBeSet() {
+        var task = ThreadTask(
+            id: 1,
+            threadId: 1,
+            thingsTaskId: "ABC123",
+            createdAt: Date(),
+            completedAt: nil
+        )
+        task.title = "My Task"
+        XCTAssertEqual(task.title, "My Task")
+    }
+
+    // MARK: - Identifiable / Hashable
+
+    func testIdentifiableUsesId() {
+        let task = ThreadTask(
+            id: 42,
+            threadId: 1,
+            thingsTaskId: "ABC123",
+            createdAt: Date(),
+            completedAt: nil
+        )
+        XCTAssertEqual(task.id, 42)
+    }
+
+    func testHashableEquality() {
+        let date = Date()
+        let task1 = ThreadTask(id: 1, threadId: 1, thingsTaskId: "ABC", createdAt: date, completedAt: nil)
+        let task2 = ThreadTask(id: 1, threadId: 1, thingsTaskId: "ABC", createdAt: date, completedAt: nil)
+        XCTAssertEqual(task1, task2)
+    }
+
+    func testHashableInequality() {
+        let date = Date()
+        let task1 = ThreadTask(id: 1, threadId: 1, thingsTaskId: "ABC", createdAt: date, completedAt: nil)
+        let task2 = ThreadTask(id: 2, threadId: 1, thingsTaskId: "DEF", createdAt: date, completedAt: nil)
+        XCTAssertNotEqual(task1, task2)
+    }
+
+    func testCanBeUsedInSet() {
+        let date = Date()
+        let task1 = ThreadTask(id: 1, threadId: 1, thingsTaskId: "ABC", createdAt: date, completedAt: nil)
+        let task2 = ThreadTask(id: 2, threadId: 1, thingsTaskId: "DEF", createdAt: date, completedAt: nil)
+        let task3 = ThreadTask(id: 1, threadId: 1, thingsTaskId: "ABC", createdAt: date, completedAt: nil)
+
+        let set: Set<ThreadTask> = [task1, task2, task3]
+        XCTAssertEqual(set.count, 2)
+    }
+
+    // MARK: - Mock (DEBUG only)
+
+    func testMockDefaults() {
+        let task = ThreadTask.mock()
+        XCTAssertEqual(task.id, 1)
+        XCTAssertEqual(task.threadId, 1)
+        XCTAssertEqual(task.thingsTaskId, "ABC123")
+        XCTAssertEqual(task.title, "Sample Task")
+        XCTAssertFalse(task.isCompleted)
+    }
+
+    func testMockCustomValues() {
+        let task = ThreadTask.mock(
+            id: 5,
+            threadId: 3,
+            thingsTaskId: "XYZ789",
+            title: "Custom Task",
+            completedAt: Date()
+        )
+        XCTAssertEqual(task.id, 5)
+        XCTAssertEqual(task.threadId, 3)
+        XCTAssertEqual(task.thingsTaskId, "XYZ789")
+        XCTAssertEqual(task.title, "Custom Task")
+        XCTAssertTrue(task.isCompleted)
+    }
+}

--- a/SeleneChat/Tests/SeleneChatTests/Services/ActionServiceTests.swift
+++ b/SeleneChat/Tests/SeleneChatTests/Services/ActionServiceTests.swift
@@ -154,4 +154,21 @@ final class ActionServiceTests: XCTestCase {
         let expectedNotes = "From Selene thread: My Thread\nEnergy: low"
         XCTAssertEqual(task.notes, expectedNotes)
     }
+
+    // MARK: - sendToThingsAndLinkThread Task Building
+
+    func testBuildThingsTaskForThreadLinkIncludesThreadName() {
+        let service = ActionService()
+        let action = makeTestAction(
+            description: "Set up test database",
+            energy: .medium,
+            timeframe: .thisWeek
+        )
+
+        let task = service.buildThingsTask(from: action, threadName: "Infrastructure")
+
+        XCTAssertEqual(task.title, "Set up test database")
+        XCTAssertTrue(task.notes.contains("Infrastructure"))
+        XCTAssertTrue(task.tags.contains("selene"))
+    }
 }

--- a/SeleneChat/Tests/SeleneChatTests/Services/Migration009ThreadTasksTests.swift
+++ b/SeleneChat/Tests/SeleneChatTests/Services/Migration009ThreadTasksTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+import SQLite
+@testable import SeleneChat
+
+final class Migration009ThreadTasksTests: XCTestCase {
+
+    var db: Connection!
+
+    override func setUpWithError() throws {
+        db = try Connection(.inMemory)
+
+        // Create prerequisite threads table (migration depends on it via FK)
+        try db.run("""
+            CREATE TABLE threads (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                why TEXT,
+                summary TEXT,
+                status TEXT DEFAULT 'active',
+                note_count INTEGER DEFAULT 0,
+                momentum_score REAL,
+                last_activity_at TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+    }
+
+    override func tearDown() {
+        db = nil
+    }
+
+    // MARK: - Migration runs
+
+    func testMigrationCreatesThreadTasksTable() throws {
+        try Migration009_ThreadTasks.run(db: db)
+
+        // Verify table exists
+        let count = try db.scalar(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='thread_tasks'"
+        ) as! Int64
+        XCTAssertEqual(count, 1)
+    }
+
+    func testMigrationCreatesIndexes() throws {
+        try Migration009_ThreadTasks.run(db: db)
+
+        // Check thread index
+        let threadIdx = try db.scalar(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_thread_tasks_thread'"
+        ) as! Int64
+        XCTAssertEqual(threadIdx, 1)
+
+        // Check things index
+        let thingsIdx = try db.scalar(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_thread_tasks_things'"
+        ) as! Int64
+        XCTAssertEqual(thingsIdx, 1)
+    }
+
+    func testMigrationIsIdempotent() throws {
+        // Running twice should not error (IF NOT EXISTS)
+        try Migration009_ThreadTasks.run(db: db)
+        try Migration009_ThreadTasks.run(db: db)
+
+        let count = try db.scalar(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='thread_tasks'"
+        ) as! Int64
+        XCTAssertEqual(count, 1)
+    }
+
+    // MARK: - Schema correctness
+
+    func testCanInsertThreadTask() throws {
+        try Migration009_ThreadTasks.run(db: db)
+
+        // Insert a thread first (FK requirement)
+        try db.run("INSERT INTO threads (name) VALUES ('Test Thread')")
+
+        // Insert a thread task
+        try db.run("""
+            INSERT INTO thread_tasks (thread_id, things_task_id)
+            VALUES (1, 'THINGS-ABC123')
+        """)
+
+        let count = try db.scalar("SELECT COUNT(*) FROM thread_tasks") as! Int64
+        XCTAssertEqual(count, 1)
+    }
+
+    func testUniqueConstraintPreventsduplicates() throws {
+        try Migration009_ThreadTasks.run(db: db)
+        try db.run("INSERT INTO threads (name) VALUES ('Test Thread')")
+
+        try db.run("""
+            INSERT INTO thread_tasks (thread_id, things_task_id)
+            VALUES (1, 'THINGS-ABC123')
+        """)
+
+        // Same thread_id + things_task_id should fail
+        XCTAssertThrowsError(try db.run("""
+            INSERT INTO thread_tasks (thread_id, things_task_id)
+            VALUES (1, 'THINGS-ABC123')
+        """))
+    }
+
+    func testDifferentThingsTaskIdsAllowed() throws {
+        try Migration009_ThreadTasks.run(db: db)
+        try db.run("INSERT INTO threads (name) VALUES ('Test Thread')")
+
+        try db.run("""
+            INSERT INTO thread_tasks (thread_id, things_task_id)
+            VALUES (1, 'THINGS-AAA')
+        """)
+        try db.run("""
+            INSERT INTO thread_tasks (thread_id, things_task_id)
+            VALUES (1, 'THINGS-BBB')
+        """)
+
+        let count = try db.scalar("SELECT COUNT(*) FROM thread_tasks") as! Int64
+        XCTAssertEqual(count, 2)
+    }
+
+    func testCreatedAtDefaultsToCurrentTimestamp() throws {
+        try Migration009_ThreadTasks.run(db: db)
+        try db.run("INSERT INTO threads (name) VALUES ('Test Thread')")
+
+        try db.run("""
+            INSERT INTO thread_tasks (thread_id, things_task_id)
+            VALUES (1, 'THINGS-ABC123')
+        """)
+
+        let createdAt = try db.scalar(
+            "SELECT created_at FROM thread_tasks WHERE id = 1"
+        ) as? String
+        XCTAssertNotNil(createdAt)
+    }
+
+    func testCompletedAtDefaultsToNull() throws {
+        try Migration009_ThreadTasks.run(db: db)
+        try db.run("INSERT INTO threads (name) VALUES ('Test Thread')")
+
+        try db.run("""
+            INSERT INTO thread_tasks (thread_id, things_task_id)
+            VALUES (1, 'THINGS-ABC123')
+        """)
+
+        let completedAt = try db.scalar(
+            "SELECT completed_at FROM thread_tasks WHERE id = 1"
+        ) as? String
+        XCTAssertNil(completedAt)
+    }
+
+    func testCanSetCompletedAt() throws {
+        try Migration009_ThreadTasks.run(db: db)
+        try db.run("INSERT INTO threads (name) VALUES ('Test Thread')")
+
+        try db.run("""
+            INSERT INTO thread_tasks (thread_id, things_task_id)
+            VALUES (1, 'THINGS-ABC123')
+        """)
+
+        try db.run("""
+            UPDATE thread_tasks SET completed_at = '2026-02-06 12:00:00'
+            WHERE id = 1
+        """)
+
+        let completedAt = try db.scalar(
+            "SELECT completed_at FROM thread_tasks WHERE id = 1"
+        ) as? String
+        XCTAssertEqual(completedAt, "2026-02-06 12:00:00")
+    }
+
+    func testAutoIncrementId() throws {
+        try Migration009_ThreadTasks.run(db: db)
+        try db.run("INSERT INTO threads (name) VALUES ('Test Thread')")
+
+        try db.run("INSERT INTO thread_tasks (thread_id, things_task_id) VALUES (1, 'AAA')")
+        try db.run("INSERT INTO thread_tasks (thread_id, things_task_id) VALUES (1, 'BBB')")
+
+        let id1 = try db.scalar("SELECT id FROM thread_tasks WHERE things_task_id = 'AAA'") as! Int64
+        let id2 = try db.scalar("SELECT id FROM thread_tasks WHERE things_task_id = 'BBB'") as! Int64
+        XCTAssertEqual(id2, id1 + 1)
+    }
+}

--- a/SeleneChat/Tests/SeleneChatTests/Services/ThreadWorkspacePromptBuilderTests.swift
+++ b/SeleneChat/Tests/SeleneChatTests/Services/ThreadWorkspacePromptBuilderTests.swift
@@ -1,0 +1,177 @@
+import XCTest
+@testable import SeleneChat
+
+final class ThreadWorkspacePromptBuilderTests: XCTestCase {
+
+    // MARK: - Initial Prompt Tests
+
+    func testBuildInitialPromptIncludesThreadContext() {
+        let thread = Thread.mock(
+            name: "Voice Input Feature",
+            why: "Reduce friction for captures",
+            summary: "Phase 1 push-to-talk complete"
+        )
+
+        let notes = [
+            Note.mock(id: 1, title: "Speech recognition research", content: "Explored SFSpeechRecognizer API."),
+            Note.mock(id: 2, title: "UX for voice", content: "Push-to-talk feels more natural than always-on.")
+        ]
+
+        let tasks = [
+            ThreadTask.mock(thingsTaskId: "VOICE-001", title: "Add global hotkey"),
+            ThreadTask.mock(thingsTaskId: "VOICE-002", title: "Test on external mic", completedAt: Date())
+        ]
+
+        let builder = ThreadWorkspacePromptBuilder()
+        let prompt = builder.buildInitialPrompt(thread: thread, notes: notes, tasks: tasks)
+
+        // Should include thread name
+        XCTAssertTrue(prompt.contains("Voice Input Feature"), "Prompt should include thread name")
+
+        // Should include note content
+        XCTAssertTrue(prompt.contains("Speech recognition research"), "Prompt should include note titles")
+        XCTAssertTrue(prompt.contains("SFSpeechRecognizer"), "Prompt should include note content")
+    }
+
+    func testBuildInitialPromptIncludesTaskState() {
+        let thread = Thread.mock(name: "Test Thread")
+        let notes = [Note.mock()]
+
+        let openTask = ThreadTask.mock(thingsTaskId: "T-001", title: "Open task")
+        let doneTask = ThreadTask.mock(thingsTaskId: "T-002", title: "Done task", completedAt: Date())
+        let tasks = [openTask, doneTask]
+
+        let builder = ThreadWorkspacePromptBuilder()
+        let prompt = builder.buildInitialPrompt(thread: thread, notes: notes, tasks: tasks)
+
+        // Should include task summary
+        XCTAssertTrue(prompt.contains("1 open"), "Prompt should mention open task count")
+        XCTAssertTrue(prompt.contains("1 completed"), "Prompt should mention completed task count")
+    }
+
+    func testBuildInitialPromptIncludesTaskTitles() {
+        let thread = Thread.mock(name: "Test Thread")
+        let notes = [Note.mock()]
+
+        let tasks = [
+            ThreadTask.mock(thingsTaskId: "T-001", title: "Research API options"),
+            ThreadTask.mock(thingsTaskId: "T-002", title: "Write integration test")
+        ]
+
+        let builder = ThreadWorkspacePromptBuilder()
+        let prompt = builder.buildInitialPrompt(thread: thread, notes: notes, tasks: tasks)
+
+        XCTAssertTrue(prompt.contains("Research API options"), "Prompt should include task titles")
+        XCTAssertTrue(prompt.contains("Write integration test"), "Prompt should include task titles")
+    }
+
+    func testBuildInitialPromptIncludesADHDFraming() {
+        let thread = Thread.mock(name: "Test Thread")
+        let builder = ThreadWorkspacePromptBuilder()
+        let prompt = builder.buildInitialPrompt(thread: thread, notes: [Note.mock()], tasks: [])
+
+        XCTAssertTrue(prompt.lowercased().contains("adhd"), "Prompt should mention ADHD")
+        XCTAssertTrue(prompt.lowercased().contains("thinking partner"), "Prompt should include thinking partner framing")
+    }
+
+    func testBuildInitialPromptIncludesActionMarkers() {
+        let thread = Thread.mock(name: "Test Thread")
+        let builder = ThreadWorkspacePromptBuilder()
+        let prompt = builder.buildInitialPrompt(thread: thread, notes: [Note.mock()], tasks: [])
+
+        XCTAssertTrue(prompt.contains("[ACTION:"), "Prompt should include action marker format")
+        XCTAssertTrue(prompt.contains("ENERGY:"), "Prompt should include energy level")
+        XCTAssertTrue(prompt.contains("TIMEFRAME:"), "Prompt should include timeframe")
+    }
+
+    func testBuildInitialPromptWithNoTasks() {
+        let thread = Thread.mock(name: "Fresh Thread")
+        let builder = ThreadWorkspacePromptBuilder()
+        let prompt = builder.buildInitialPrompt(thread: thread, notes: [Note.mock()], tasks: [])
+
+        XCTAssertTrue(prompt.contains("No tasks"), "Prompt should indicate no tasks exist yet")
+    }
+
+    // MARK: - Follow-Up Prompt Tests
+
+    func testBuildFollowUpPromptIncludesConversationHistory() {
+        let thread = Thread.mock(name: "Test Thread")
+        let conversationHistory = """
+        User: What should I focus on next?
+        Assistant: Based on your notes, the API integration seems most urgent.
+        """
+
+        let builder = ThreadWorkspacePromptBuilder()
+        let prompt = builder.buildFollowUpPrompt(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: [],
+            conversationHistory: conversationHistory,
+            currentQuery: "Break that down into tasks"
+        )
+
+        XCTAssertTrue(prompt.contains("What should I focus on next?"), "Prompt should include conversation history")
+        XCTAssertTrue(prompt.contains("API integration seems most urgent"), "Prompt should include assistant response")
+    }
+
+    func testBuildFollowUpPromptIncludesCurrentQuery() {
+        let thread = Thread.mock(name: "Test Thread")
+        let builder = ThreadWorkspacePromptBuilder()
+        let prompt = builder.buildFollowUpPrompt(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: [],
+            conversationHistory: "User: Q\nAssistant: A",
+            currentQuery: "What are the next steps?"
+        )
+
+        XCTAssertTrue(prompt.contains("What are the next steps?"), "Prompt should include current query")
+    }
+
+    func testBuildFollowUpPromptIncludesTaskState() {
+        let thread = Thread.mock(name: "Test Thread")
+        let tasks = [
+            ThreadTask.mock(thingsTaskId: "T-001", title: "Open task"),
+            ThreadTask.mock(thingsTaskId: "T-002", title: "Done task", completedAt: Date())
+        ]
+
+        let builder = ThreadWorkspacePromptBuilder()
+        let prompt = builder.buildFollowUpPrompt(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: tasks,
+            conversationHistory: "User: Q\nAssistant: A",
+            currentQuery: "Next?"
+        )
+
+        XCTAssertTrue(prompt.contains("1 open"), "Follow-up should include current task state")
+    }
+
+    func testBuildFollowUpPromptIncludesActionMarkers() {
+        let thread = Thread.mock(name: "Test Thread")
+        let builder = ThreadWorkspacePromptBuilder()
+        let prompt = builder.buildFollowUpPrompt(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: [],
+            conversationHistory: "User: Q\nAssistant: A",
+            currentQuery: "Next?"
+        )
+
+        XCTAssertTrue(prompt.contains("[ACTION:"), "Follow-up prompt should include action marker format")
+    }
+
+    func testBuildFollowUpPromptIncludesThreadContext() {
+        let thread = Thread.mock(name: "Architecture Decisions")
+        let builder = ThreadWorkspacePromptBuilder()
+        let prompt = builder.buildFollowUpPrompt(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: [],
+            conversationHistory: "User: Q\nAssistant: A",
+            currentQuery: "Next?"
+        )
+
+        XCTAssertTrue(prompt.contains("Architecture Decisions"), "Follow-up should include thread name")
+    }
+}

--- a/SeleneChat/Tests/SeleneChatTests/ViewModels/ThreadWorkspaceChatViewModelTests.swift
+++ b/SeleneChat/Tests/SeleneChatTests/ViewModels/ThreadWorkspaceChatViewModelTests.swift
@@ -1,0 +1,244 @@
+import XCTest
+@testable import SeleneChat
+
+@MainActor
+final class ThreadWorkspaceChatViewModelTests: XCTestCase {
+
+    // MARK: - Initialization
+
+    func testInitialState() {
+        let thread = Thread.mock(name: "Test Thread")
+        let vm = ThreadWorkspaceChatViewModel(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: []
+        )
+
+        XCTAssertTrue(vm.messages.isEmpty)
+        XCTAssertFalse(vm.isProcessing)
+        XCTAssertTrue(vm.pendingActions.isEmpty)
+    }
+
+    func testInitStoresThreadContext() {
+        let thread = Thread.mock(name: "Voice Feature")
+        let notes = [Note.mock(id: 1), Note.mock(id: 2)]
+        let tasks = [ThreadTask.mock(thingsTaskId: "T-1")]
+
+        let vm = ThreadWorkspaceChatViewModel(
+            thread: thread,
+            notes: notes,
+            tasks: tasks
+        )
+
+        XCTAssertEqual(vm.thread.name, "Voice Feature")
+        XCTAssertEqual(vm.notes.count, 2)
+        XCTAssertEqual(vm.tasks.count, 1)
+    }
+
+    // MARK: - Action Extraction from Response
+
+    func testProcessResponseExtractsActions() {
+        let thread = Thread.mock(name: "Test Thread")
+        let vm = ThreadWorkspaceChatViewModel(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: []
+        )
+
+        let responseWithActions = """
+        Here are some next steps for your project.
+        [ACTION: Write integration tests | ENERGY: medium | TIMEFRAME: this-week]
+        [ACTION: Set up CI pipeline | ENERGY: high | TIMEFRAME: today]
+        Let me know if you want to explore further.
+        """
+
+        vm.processResponse(responseWithActions)
+
+        // Should extract 2 actions
+        XCTAssertEqual(vm.pendingActions.count, 2)
+        XCTAssertEqual(vm.pendingActions[0].description, "Write integration tests")
+        XCTAssertEqual(vm.pendingActions[0].energy, .medium)
+        XCTAssertEqual(vm.pendingActions[1].description, "Set up CI pipeline")
+        XCTAssertEqual(vm.pendingActions[1].timeframe, .today)
+    }
+
+    func testProcessResponseAddsCleanedMessage() {
+        let thread = Thread.mock(name: "Test Thread")
+        let vm = ThreadWorkspaceChatViewModel(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: []
+        )
+
+        let responseWithActions = """
+        Here are some steps.
+        [ACTION: Do something | ENERGY: low | TIMEFRAME: someday]
+        Let me know.
+        """
+
+        vm.processResponse(responseWithActions)
+
+        // Should have one assistant message with actions removed
+        XCTAssertEqual(vm.messages.count, 1)
+        XCTAssertEqual(vm.messages[0].role, .assistant)
+        XCTAssertFalse(vm.messages[0].content.contains("[ACTION:"))
+        XCTAssertTrue(vm.messages[0].content.contains("Here are some steps"))
+        XCTAssertTrue(vm.messages[0].content.contains("Let me know"))
+    }
+
+    func testProcessResponseWithNoActions() {
+        let thread = Thread.mock(name: "Test Thread")
+        let vm = ThreadWorkspaceChatViewModel(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: []
+        )
+
+        vm.processResponse("Just a normal response with no actions.")
+
+        XCTAssertTrue(vm.pendingActions.isEmpty)
+        XCTAssertEqual(vm.messages.count, 1)
+        XCTAssertEqual(vm.messages[0].content, "Just a normal response with no actions.")
+    }
+
+    // MARK: - Dismiss Actions
+
+    func testDismissActionsClearsPending() {
+        let thread = Thread.mock(name: "Test Thread")
+        let vm = ThreadWorkspaceChatViewModel(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: []
+        )
+
+        // Simulate having pending actions
+        vm.processResponse("[ACTION: Task 1 | ENERGY: high | TIMEFRAME: today]")
+        XCTAssertEqual(vm.pendingActions.count, 1)
+
+        vm.dismissActions()
+
+        XCTAssertTrue(vm.pendingActions.isEmpty)
+    }
+
+    // MARK: - Add User Message
+
+    func testAddUserMessage() {
+        let thread = Thread.mock(name: "Test Thread")
+        let vm = ThreadWorkspaceChatViewModel(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: []
+        )
+
+        vm.addUserMessage("What should I work on next?")
+
+        XCTAssertEqual(vm.messages.count, 1)
+        XCTAssertEqual(vm.messages[0].role, .user)
+        XCTAssertEqual(vm.messages[0].content, "What should I work on next?")
+        XCTAssertEqual(vm.messages[0].llmTier, .local)
+    }
+
+    // MARK: - Conversation History
+
+    func testConversationHistoryBuildsFromMessages() {
+        let thread = Thread.mock(name: "Test Thread")
+        let vm = ThreadWorkspaceChatViewModel(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: []
+        )
+
+        // Build up a conversation
+        vm.addUserMessage("First question")
+        vm.processResponse("First answer")
+        vm.addUserMessage("Follow-up question")
+        vm.processResponse("Follow-up answer")
+
+        let history = vm.buildConversationHistory()
+
+        XCTAssertTrue(history.contains("First question"))
+        XCTAssertTrue(history.contains("First answer"))
+        XCTAssertTrue(history.contains("Follow-up question"))
+        XCTAssertTrue(history.contains("Follow-up answer"))
+    }
+
+    // MARK: - Prompt Building
+
+    func testFirstMessageUsesInitialPrompt() {
+        let thread = Thread.mock(name: "Architecture Thread")
+        let vm = ThreadWorkspaceChatViewModel(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: [ThreadTask.mock(title: "Existing task")]
+        )
+
+        let prompt = vm.buildPrompt(for: "What should I focus on?")
+
+        // Initial prompt should include thread name and task context
+        XCTAssertTrue(prompt.contains("Architecture Thread"))
+        XCTAssertTrue(prompt.contains("Existing task"))
+        XCTAssertTrue(prompt.contains("[ACTION:"))
+    }
+
+    func testSubsequentMessageUsesFollowUpPrompt() {
+        let thread = Thread.mock(name: "Test Thread")
+        let vm = ThreadWorkspaceChatViewModel(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: []
+        )
+
+        // Add prior conversation
+        vm.addUserMessage("First question")
+        vm.processResponse("First answer")
+
+        let prompt = vm.buildPrompt(for: "Follow-up question")
+
+        // Follow-up prompt should include conversation history
+        XCTAssertTrue(prompt.contains("First question"))
+        XCTAssertTrue(prompt.contains("First answer"))
+        XCTAssertTrue(prompt.contains("Follow-up question"))
+    }
+
+    // MARK: - Multiple Action Rounds
+
+    func testNewActionsReplacePreviousPending() {
+        let thread = Thread.mock(name: "Test Thread")
+        let vm = ThreadWorkspaceChatViewModel(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: []
+        )
+
+        // First response with actions
+        vm.processResponse("[ACTION: Task A | ENERGY: high | TIMEFRAME: today]")
+        XCTAssertEqual(vm.pendingActions.count, 1)
+        XCTAssertEqual(vm.pendingActions[0].description, "Task A")
+
+        // Second response with different actions - should replace
+        vm.processResponse("[ACTION: Task B | ENERGY: low | TIMEFRAME: someday]")
+        XCTAssertEqual(vm.pendingActions.count, 1)
+        XCTAssertEqual(vm.pendingActions[0].description, "Task B")
+    }
+
+    // MARK: - Update Tasks
+
+    func testUpdateTasksUpdatesContext() {
+        let thread = Thread.mock(name: "Test Thread")
+        let vm = ThreadWorkspaceChatViewModel(
+            thread: thread,
+            notes: [Note.mock()],
+            tasks: []
+        )
+
+        XCTAssertTrue(vm.tasks.isEmpty)
+
+        let newTasks = [
+            ThreadTask.mock(thingsTaskId: "T-1", title: "New task")
+        ]
+        vm.updateTasks(newTasks)
+
+        XCTAssertEqual(vm.tasks.count, 1)
+        XCTAssertEqual(vm.tasks[0].title, "New task")
+    }
+}

--- a/database/migrations/016_thread_tasks.sql
+++ b/database/migrations/016_thread_tasks.sql
@@ -1,0 +1,24 @@
+-- Migration 016: Thread Tasks
+-- Links Things tasks to semantic threads for workspace view
+-- Created: 2026-02-06
+
+-- Table to track which Things tasks belong to which threads
+CREATE TABLE IF NOT EXISTS thread_tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    thread_id INTEGER NOT NULL,
+    things_task_id TEXT NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    completed_at TEXT,
+    FOREIGN KEY (thread_id) REFERENCES threads(id) ON DELETE CASCADE,
+    UNIQUE(thread_id, things_task_id)
+);
+
+-- Index for querying tasks by thread
+CREATE INDEX IF NOT EXISTS idx_thread_tasks_thread ON thread_tasks(thread_id);
+
+-- Index for looking up thread by Things task ID (for sync)
+CREATE INDEX IF NOT EXISTS idx_thread_tasks_things ON thread_tasks(things_task_id);
+
+-- Index for finding incomplete tasks
+CREATE INDEX IF NOT EXISTS idx_thread_tasks_incomplete ON thread_tasks(thread_id)
+    WHERE completed_at IS NULL;

--- a/docs/plans/2026-02-06-test-environment-isolation-design.md
+++ b/docs/plans/2026-02-06-test-environment-isolation-design.md
@@ -1,0 +1,185 @@
+# Test Environment Isolation Design
+
+**Date:** 2026-02-06
+**Status:** Ready
+**Topic:** infrastructure
+
+---
+
+## Problem
+
+Claude Code currently has access to the production database at `~/selene-data/selene.db` containing personal notes, threads, and conversations. Development and testing should never touch this data, but test data needs to be realistic enough to reproduce production bugs.
+
+---
+
+## Solution
+
+A complete test environment with:
+- Anonymized snapshot of production data (realistic patterns, no personal content)
+- Separate paths for all data stores (SQLite, LanceDB, Obsidian vault, digests)
+- Environment-based switching between production and test modes
+- On-demand script to refresh anonymized data from production
+
+---
+
+## Test Environment Paths
+
+| Component | Production | Test |
+|-----------|------------|------|
+| SQLite DB | `~/selene-data/selene.db` | `selene-n8n/data-test/selene.db` |
+| LanceDB vectors | `~/selene-data/vectors.lance` | `selene-n8n/data-test/vectors.lance` |
+| Obsidian vault | `selene-n8n/vault/` | `selene-n8n/data-test/vault/` |
+| Digests | `selene-n8n/data/digests/` | `selene-n8n/data-test/digests/` |
+| iMessage | Sends to phone | Writes to file only |
+
+---
+
+## Anonymization Script
+
+**Script:** `scripts/create-test-db.sh`
+
+**What it does:**
+1. Copies production SQLite to `data-test/selene.db`
+2. Runs SQL transformations to scrub personal content
+3. Regenerates embeddings for anonymized content (via Ollama)
+4. Copies LanceDB and rebuilds with anonymized vectors
+
+### Anonymization Rules
+
+| Table | Field | Transformation |
+|-------|-------|----------------|
+| `raw_notes` | title | `"Note " \|\| printf('%05d', id)` |
+| `raw_notes` | content | Lorem ipsum matching original word count |
+| `processed_notes` | concepts | `"concept_" \|\| row_number` |
+| `processed_notes` | summary | Generic summary text |
+| `threads` | name | `"Thread " \|\| printf('%03d', id)` |
+| `threads` | summary | `"Thread about concept_X and concept_Y"` |
+| `chat_sessions` | All fields | Truncate table entirely |
+| `conversations` | All fields | Truncate table entirely |
+| `conversation_memories` | All fields | Truncate table entirely |
+
+### What Stays Intact
+- All timestamps, IDs, foreign keys
+- Status flags and processing states
+- Association scores and relationships
+- Note/thread counts and structure
+
+### Runtime
+~2-5 minutes depending on note count (embedding regeneration is the slow part)
+
+---
+
+## Environment Switching
+
+A single environment variable controls everything:
+
+```bash
+SELENE_ENV=test  # or "production" (default)
+```
+
+### Config Behavior
+
+When `SELENE_ENV=test`, `src/lib/config.ts` returns:
+- `dbPath` → `selene-n8n/data-test/selene.db`
+- `vectorsPath` → `selene-n8n/data-test/vectors.lance`
+- `vaultPath` → `selene-n8n/data-test/vault/`
+- `digestsPath` → `selene-n8n/data-test/digests/`
+- `imessageEnabled` → `false` (writes to file instead)
+
+### Usage
+
+```bash
+# Run any workflow in test mode
+SELENE_ENV=test npx ts-node src/workflows/process-llm.ts
+
+# Or export for entire session
+export SELENE_ENV=test
+```
+
+### SeleneChat
+Already uses `data-test/` path when running as CLI build (not .app bundle), so no changes needed.
+
+---
+
+## Claude Code Isolation
+
+### Default to Test Mode
+
+Create `.env.development` at project root:
+```bash
+SELENE_ENV=test
+SELENE_DB_PATH=/Users/chaseeasterling/Documents/GitHub/selene-n8n/data-test/selene.db
+```
+
+Claude Code and development tools will source this automatically.
+
+### Fail-Safe Protection
+
+The anonymization script adds a marker to the test database:
+- Table: `_selene_metadata`
+- Row: `key = 'environment'`, `value = 'test'`
+
+When `SELENE_ENV=test`, `config.ts` validates this marker exists. If you accidentally point test mode at production, it fails immediately with a clear error:
+
+```
+Error: SELENE_ENV=test but database is not a test database.
+Expected _selene_metadata.environment = 'test'.
+Run ./scripts/create-test-db.sh to create a test database.
+```
+
+---
+
+## Implementation Tasks
+
+### Files to Create
+1. `scripts/create-test-db.sh` - Anonymization script
+2. `.env.development` - Test environment variables
+3. `data-test/.gitkeep` - Ensure directory exists (contents gitignored)
+
+### Files to Modify
+1. `src/lib/config.ts` - Add environment switching logic, test paths
+2. `src/lib/lancedb.ts` - Use config for vector path instead of deriving
+3. `src/workflows/send-digest.ts` - Write to file when iMessage disabled
+4. `SeleneChat/.../ObsidianService.swift` - Use config-based vault path
+5. `.gitignore` - Ensure `data-test/` contents are ignored
+
+### Database Changes
+1. Add `_selene_metadata` table with `environment` flag
+2. Anonymization script sets `environment = 'test'`
+3. Config validates this flag on startup in test mode
+
+---
+
+## Acceptance Criteria
+
+- [ ] `./scripts/create-test-db.sh` creates anonymized copy in under 5 minutes
+- [ ] All workflows work with `SELENE_ENV=test`
+- [ ] SeleneChat dev builds use test database
+- [ ] Running test workflows never touches `~/selene-data/`
+- [ ] Digest workflow writes to file instead of sending iMessage
+- [ ] Obsidian export goes to `data-test/vault/`
+- [ ] Accidental production access fails fast with clear error
+
+---
+
+## ADHD Check
+
+- [x] **Reduces friction?** Yes - one command to create test env, automatic switching
+- [x] **Makes things visible?** Yes - clear error messages if misconfigured
+- [x] **Externalizes cognition?** Yes - don't have to remember to switch modes
+
+---
+
+## Scope Check
+
+- [x] Less than 1 week of focused work
+- [x] No external dependencies
+- [x] Clear boundaries (no feature creep)
+
+---
+
+## Related
+
+- `src/lib/config.ts` - Primary configuration
+- `scripts/cleanup-tests.sh` - Existing test cleanup (will be superseded)
+- `.claude/OPERATIONS.md` - Testing procedures documentation

--- a/docs/plans/2026-02-06-thread-workspace-design.md
+++ b/docs/plans/2026-02-06-thread-workspace-design.md
@@ -1,8 +1,58 @@
 # Thread Workspace Design
 
 **Date:** 2026-02-06
-**Status:** Ready
+**Status:** In Progress
 **Topic:** selenechat
+**Branch:** `feature/thread-workspace`
+
+---
+
+## Development Handoff
+
+### Current State (Phase 1 Complete)
+
+Phase 1 is implemented and ready to test. The branch is pushed to GitHub.
+
+### To Continue Development on Mac mini
+
+```bash
+# 1. Fetch and checkout the branch
+cd ~/path/to/selene-n8n
+git fetch origin
+git checkout feature/thread-workspace
+
+# 2. Build and run
+cd SeleneChat
+swift build
+swift run
+```
+
+### To Test Thread Workspace
+
+1. Launch app → dismiss briefing
+2. Go to **Today** view (first sidebar item)
+3. Look for **"Heating Up"** column on the right side
+4. Tap a thread → Thread Workspace should open
+
+**If no threads in "Heating Up":** Check database has active threads with momentum:
+```bash
+sqlite3 data/selene.db "SELECT id, name, status, momentum_score FROM threads WHERE status='active';"
+```
+
+### Files Changed in Phase 1
+
+| File | Purpose |
+|------|---------|
+| `database/migrations/016_thread_tasks.sql` | SQL migration for thread_tasks table |
+| `SeleneChat/Sources/Services/Migrations/Migration009_ThreadTasks.swift` | Swift migration |
+| `SeleneChat/Sources/Models/ThreadTask.swift` | ThreadTask model |
+| `SeleneChat/Sources/Views/ThreadWorkspaceView.swift` | Main workspace UI |
+| `SeleneChat/Sources/Services/DatabaseService.swift` | Added getTasksForThread, linkTaskToThread, getThreadById |
+| `SeleneChat/Sources/App/ContentView.swift` | Navigation to workspace from Today view |
+
+### Next: Phase 2
+
+Add chat to the workspace for task creation and planning. See "Phases" section below.
 
 ---
 

--- a/docs/plans/2026-02-06-thread-workspace-design.md
+++ b/docs/plans/2026-02-06-thread-workspace-design.md
@@ -1,0 +1,222 @@
+# Thread Workspace Design
+
+**Date:** 2026-02-06
+**Status:** Ready
+**Topic:** selenechat
+
+---
+
+## Problem
+
+Tasks lose connection to their "why." When a task exists in Things without thread context:
+- You skip it (no motivation without meaning)
+- You do it wrong (lost context about purpose)
+- You re-derive the purpose each time (wastes energy)
+
+Completing tasks doesn't feed back to threads — progress feels invisible.
+
+---
+
+## Solution
+
+A **Thread Workspace** in SeleneChat where you can:
+- See a thread with full context (name, why, summary)
+- See all tasks linked to that thread
+- Chat to plan, break down, and generate tasks
+- Have tasks update and "what's next" surface automatically
+
+---
+
+## Design
+
+### Entry Point
+
+From SeleneChat's thread list, tap a thread → enter Thread Workspace mode.
+
+### Workspace Layout
+
+```
+┌─────────────────────────────────────────┐
+│ [← Back]           Thread Workspace     │
+├─────────────────────────────────────────┤
+│ ADHD System Design                      │
+│ Why: Build tools that externalize       │
+│ executive function                      │
+│                                         │
+│ Momentum: ●●●○○  Last: 2 days ago       │
+├─────────────────────────────────────────┤
+│ Tasks (3)                    [+ Add]    │
+│ ○ Research time-blocking approaches     │
+│ ○ Draft capture interface spec          │
+│ ● Write ADHD principles doc  ✓ Done     │
+├─────────────────────────────────────────┤
+│ Chat                                    │
+│                                         │
+│ ┌─────────────────────────────────────┐ │
+│ │ What would you like to explore?     │ │
+│ └─────────────────────────────────────┘ │
+└─────────────────────────────────────────┘
+```
+
+**Key elements:**
+- Thread name + "why" always visible (no re-deriving)
+- Momentum indicator (from existing thread data)
+- Tasks list showing linked Things tasks
+- Chat area for planning/brainstorming
+
+### Chat Capabilities
+
+Chat is scoped to the thread with automatic context:
+- Thread summary and "why"
+- Recent notes in the thread
+- Current tasks (from Things via the link)
+
+| You say | System does |
+|---------|-------------|
+| "Break down [task]" | Generates subtasks, offers to create in Things |
+| "What do I need for this?" | Generates equipment/materials list |
+| "What's blocking this?" | Explores blockers, suggests next steps |
+| "Let's brainstorm [aspect]" | Open-ended thinking with thread context |
+| "What's next?" | Recommends next task based on thread state |
+| "Update the summary" | Regenerates thread summary from progress |
+
+**Task creation flow:**
+1. Chat generates task suggestions
+2. User confirms ("yes, create those" or edits first)
+3. Tasks created in Things via URL scheme
+4. Link stored in Selene (`thread_tasks` table)
+5. Tasks appear in workspace task list
+
+**Principle:** Chat proposes, user confirms. Nothing created without explicit approval.
+
+---
+
+## Data Model
+
+### New Table: thread_tasks
+
+```sql
+CREATE TABLE thread_tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    thread_id INTEGER NOT NULL,
+    things_task_id TEXT NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    completed_at TEXT,
+    FOREIGN KEY (thread_id) REFERENCES threads(id) ON DELETE CASCADE,
+    UNIQUE(thread_id, things_task_id)
+);
+
+CREATE INDEX idx_thread_tasks_thread ON thread_tasks(thread_id);
+CREATE INDEX idx_thread_tasks_things ON thread_tasks(things_task_id);
+```
+
+**Why a new table (vs. adding thread_id to task_metadata):**
+- `task_metadata` is for tasks extracted from notes (automatic flow)
+- `thread_tasks` is for tasks created via conversation (explicit flow)
+- Keeps the two sources separate and clear
+
+### Completion Sync
+
+Extend existing `sync-things-status.sh` to also update `thread_tasks.completed_at` when Things marks a task complete.
+
+---
+
+## Implementation
+
+### Swift Components
+
+**ThreadWorkspaceView** — Main workspace UI
+- Header: thread name, why, momentum
+- Task list: fetched from Things via `thread_tasks` links
+- Chat area: scoped to this thread
+
+**ThreadTaskService** — Manages thread ↔ task relationship
+- `getTasksForThread(threadId)` → queries `thread_tasks`, fetches from Things
+- `createTaskForThread(threadId, task)` → creates in Things, stores link
+- `syncCompletionStatus()` → updates completion from Things
+
+**ThreadChatViewModel** — Chat logic scoped to thread
+- Builds context from: thread summary, why, recent notes, current tasks
+- Handles commands: "break down", "what do I need", "what's next"
+- Parses task suggestions from LLM response
+- Confirmation flow before creating tasks
+
+### Thread Summary Updates
+
+Extend `reconsolidate-threads.ts` to include task progress:
+
+**New inputs to summary generation:**
+- Completed tasks since last summary
+- Open tasks remaining
+- Recent notes (existing)
+
+**"What's next" logic:**
+1. Get open tasks for thread
+2. Consider: task age, thread momentum
+3. LLM recommends which to tackle with brief reasoning
+
+---
+
+## Phases
+
+### Phase 1: Foundation
+- Add `thread_tasks` table migration
+- ThreadWorkspaceView with header + task list (read-only)
+- Navigate from thread list to workspace
+- No chat yet — just see thread + tasks together
+
+### Phase 2: Task Creation
+- Add chat to workspace (scoped to thread)
+- "Break down" and task generation commands
+- Create tasks in Things + store links
+- Confirmation flow before creation
+
+### Phase 3: Feedback Loop
+- Extend `sync-things-status.sh` to update `thread_tasks`
+- "What's next" command
+- Thread summary includes task progress
+- Completion triggers summary refresh
+
+---
+
+## Acceptance Criteria
+
+- [ ] Can select a thread and see its tasks in one view
+- [ ] Thread "why" is always visible (no re-deriving purpose)
+- [ ] Can chat to break down tasks, generate subtasks
+- [ ] Generated tasks go to Things and link to thread
+- [ ] Completing tasks updates thread and surfaces "what's next"
+
+---
+
+## ADHD Check
+
+| Principle | How This Helps |
+|-----------|----------------|
+| Externalize working memory | Thread "why" always visible, not held mentally |
+| Make progress visible | Task completion updates summary |
+| Reduce friction | One place for thread + tasks + planning |
+| Surface next action | "What's next" removes decision fatigue |
+| Visual over mental | See everything in one workspace |
+
+---
+
+## Scope Check
+
+**Phase 1 estimate:** Database migration + read-only workspace view
+**Phase 2 estimate:** Chat integration + task creation
+**Phase 3 estimate:** Sync extension + summary updates
+
+Each phase is independently useful:
+- Phase 1: See thread + tasks together (value even without chat)
+- Phase 2: Plan and create tasks (core workflow)
+- Phase 3: Feedback loop (polishes the experience)
+
+---
+
+## Related
+
+- `docs/plans/2026-02-05-selene-thinking-partner-design.md` — Thinking Partner (chat capabilities)
+- `docs/plans/2026-01-04-selene-thread-system-design.md` — Thread system design
+- `scripts/things-bridge/sync-things-status.sh` — Existing Things sync
+- `.claude/ADHD_Principles.md` — ADHD design framework

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -45,7 +45,7 @@ These have acceptance criteria, ADHD check, and scope check. Ready to create a b
 
 | Date | Document | Topic | Notes |
 |------|----------|-------|-------|
-| - | - | - | No ready designs |
+| 2026-02-06 | 2026-02-06-test-environment-isolation-design.md | infrastructure | Complete test isolation with anonymized data |
 
 ---
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -45,6 +45,7 @@ These have acceptance criteria, ADHD check, and scope check. Ready to create a b
 
 | Date | Document | Topic | Notes |
 |------|----------|-------|-------|
+| 2026-02-06 | 2026-02-06-thread-workspace-design.md | selenechat | Thread workspace with tasks, planning chat, feedback loop |
 | 2026-02-06 | 2026-02-06-test-environment-isolation-design.md | infrastructure | Complete test isolation with anonymized data |
 
 ---


### PR DESCRIPTION
## Summary

- **Phase 1**: Read-only Thread Workspace view showing thread context (name, WHY, summary, momentum), linked tasks from Things, and associated notes in a single pane
- **Phase 2**: Thread-scoped chat with LLM-powered task suggestions. Actions extracted from responses appear in a confirmation banner; user approves to create in Things and link to thread via `thread_tasks`
- Supporting: `thread_tasks` migration, ThreadTask model, design docs, test environment isolation design

## Key Changes

- `ThreadWorkspaceView` with HSplitView layout (context/tasks/notes | chat)
- `ThreadWorkspaceChatViewModel` - lightweight VM scoped to one thread
- `ThreadWorkspacePromptBuilder` - includes task state in LLM context
- `ActionService.sendToThingsAndLinkThread()` - create + link in one call
- Pending actions confirmation banner (Create in Things / Dismiss)
- 59 new tests across unit, service, and integration layers (353 total, 0 failures)

## Test plan

- [x] `swift test` passes (353 tests, 0 failures)
- [x] `swift build` succeeds with no warnings
- [ ] Manual: open app, navigate to thread workspace, verify context/tasks/notes display
- [ ] Manual: send chat message, verify LLM response with action markers
- [ ] Manual: confirm actions banner creates tasks in Things and links to thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)