### PR TITLE
feat: Thread Workspace Phase 3 — feedback loop

### DIFF
--- a/.claude/PROJECT-STATUS.md
+++ b/.claude/PROJECT-STATUS.md
@@ -1,7 +1,7 @@
 # Selene Project - Current Status
 
 **Last Updated:** 2026-02-13
-**Status:** Menu Bar Orchestrator | Voice Memo Transcription | Morning Briefing Redesign | Living System Active
+**Status:** Thread Workspace Phase 3 | Living System Active
 
 ---
 
@@ -22,6 +22,7 @@ Notes form **threads** - lines of thinking that span multiple notes, have underl
 All three "Ready" designs from 2026-02-12 are now implemented and merged. The system has grown significantly: menu bar orchestrator manages workflow scheduling, voice memos are auto-transcribed via whisper.cpp, and the morning briefing got a full redesign with structured cards.
 
 ### Recent Completions
+- **Thread Workspace Phase 3** (2026-02-13) - On-demand Things sync, task completion momentum boost, LLM "what's next" recommendation
 - **Morning Briefing Redesign** (2026-02-13) - Structured cards, deep context chat, cross-thread connections
 - **Menu Bar Orchestrator** (2026-02-13) - Silver Crystal icon, WorkflowScheduler replaces launchd, animated processing state
 - **Voice Memo Transcription** (2026-02-13) - whisper.cpp pipeline, auto-detect new recordings, Selene ingestion

--- a/SeleneChat/Sources/Services/ThingsURLService.swift
+++ b/SeleneChat/Sources/Services/ThingsURLService.swift
@@ -234,4 +234,119 @@ class ThingsURLService {
         let url = URL(string: "things:///")!
         return NSWorkspace.shared.urlForApplication(toOpen: url) != nil
     }
+
+    // MARK: - Task Status Sync
+
+    /// Parsed response from get-task-status.scpt
+    struct TaskStatusResult {
+        let id: String
+        let status: String  // "open", "completed", "canceled"
+        let name: String
+        let completionDate: String?  // "YYYY-MM-DD" or nil
+    }
+
+    /// Path to the get-task-status AppleScript
+    private var getTaskStatusScriptPath: String {
+        "/Users/chaseeasterling/selene-n8n/scripts/things-bridge/get-task-status.scpt"
+    }
+
+    /// Parse JSON response from get-task-status.scpt
+    static func parseTaskStatusResponse(_ jsonString: String) -> TaskStatusResult? {
+        guard let data = jsonString.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        // Check for error response
+        if json["error"] != nil {
+            return nil
+        }
+
+        guard let id = json["id"] as? String,
+              let status = json["status"] as? String,
+              let name = json["name"] as? String else {
+            return nil
+        }
+
+        let completionDate = json["completion_date"] as? String
+
+        return TaskStatusResult(
+            id: id,
+            status: status,
+            name: name,
+            completionDate: completionDate
+        )
+    }
+
+    /// Query Things for a single task's status via AppleScript
+    func getTaskStatus(thingsTaskId: String) async throws -> TaskStatusResult? {
+        guard FileManager.default.fileExists(atPath: getTaskStatusScriptPath) else {
+            print("[ThingsURLService] get-task-status.scpt not found")
+            return nil
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = [getTaskStatusScriptPath, thingsTaskId]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        guard process.terminationStatus == 0, !output.isEmpty else {
+            return nil
+        }
+
+        return Self.parseTaskStatusResponse(output)
+    }
+
+    /// Sync task statuses for a list of incomplete tasks.
+    /// Returns the Things IDs of tasks that were newly marked as completed.
+    func syncTaskStatuses(for tasks: [ThreadTask], databaseService: DatabaseService) async -> [String] {
+        var newlyCompleted: [String] = []
+
+        for task in tasks where !task.isCompleted {
+            do {
+                guard let status = try await getTaskStatus(thingsTaskId: task.thingsTaskId) else {
+                    continue
+                }
+
+                if status.status == "completed" || status.status == "canceled" {
+                    let completionDate: Date
+                    if let dateStr = status.completionDate {
+                        let formatter = DateFormatter()
+                        formatter.dateFormat = "yyyy-MM-dd"
+                        completionDate = formatter.date(from: dateStr) ?? Date()
+                    } else {
+                        completionDate = Date()
+                    }
+
+                    try await databaseService.markThreadTaskCompleted(
+                        thingsTaskId: task.thingsTaskId,
+                        completedAt: completionDate
+                    )
+
+                    try await databaseService.recordThreadActivity(
+                        threadId: task.threadId,
+                        type: "task_completed",
+                        timestamp: completionDate
+                    )
+
+                    newlyCompleted.append(task.thingsTaskId)
+                    print("[ThingsURLService] Task \(task.thingsTaskId) synced as completed")
+                }
+            } catch {
+                print("[ThingsURLService] Failed to sync task \(task.thingsTaskId): \(error)")
+            }
+        }
+
+        return newlyCompleted
+    }
 }

--- a/SeleneChat/Sources/ViewModels/ThreadWorkspaceChatViewModel.swift
+++ b/SeleneChat/Sources/ViewModels/ThreadWorkspaceChatViewModel.swift
@@ -136,10 +136,17 @@ class ThreadWorkspaceChatViewModel: ObservableObject {
 
     /// Build the appropriate prompt for the current conversation state.
     func buildPrompt(for query: String) -> String {
+        // Check for "what's next" query first
+        if promptBuilder.isWhatsNextQuery(query) {
+            return promptBuilder.buildWhatsNextPrompt(
+                thread: thread,
+                notes: notes,
+                tasks: tasks
+            )
+        }
+
         // If no prior conversation, use initial prompt
         let priorMessages = messages.filter { $0.role != .system }
-        // Only user+assistant messages before the current user message count as history
-        // The current user message was just added, so check for prior assistant messages
         let hasHistory = priorMessages.contains { $0.role == .assistant }
 
         if hasHistory {

--- a/SeleneChat/Sources/Views/ThreadWorkspaceView.swift
+++ b/SeleneChat/Sources/Views/ThreadWorkspaceView.swift
@@ -359,6 +359,17 @@ struct ThreadWorkspaceView: View {
             // Load tasks for thread
             tasks = try await databaseService.getTasksForThread(threadId)
 
+            // Sync incomplete tasks with Things (on-demand)
+            let newlyCompleted = await ThingsURLService.shared.syncTaskStatuses(
+                for: tasks,
+                databaseService: databaseService
+            )
+
+            // Reload tasks if any were completed
+            if !newlyCompleted.isEmpty {
+                tasks = try await databaseService.getTasksForThread(threadId)
+            }
+
             // Load notes for thread
             if let result = try await databaseService.getThreadByName(loadedThread.name) {
                 notes = result.1

--- a/SeleneChat/Tests/SeleneChatTests/Services/ThingsSyncTests.swift
+++ b/SeleneChat/Tests/SeleneChatTests/Services/ThingsSyncTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import SeleneChat
+
+final class ThingsSyncTests: XCTestCase {
+
+    func testParseTaskStatusResponseCompleted() {
+        let json = """
+        {"id": "ABC123", "status": "completed", "name": "Test Task", "completion_date": "2026-02-13", "modification_date": "2026-02-13", "creation_date": "2026-02-10", "project": null, "area": null, "tags": ["selene"]}
+        """
+
+        let result = ThingsURLService.parseTaskStatusResponse(json)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, "completed")
+        XCTAssertEqual(result?.name, "Test Task")
+        XCTAssertNotNil(result?.completionDate)
+    }
+
+    func testParseTaskStatusResponseOpen() {
+        let json = """
+        {"id": "DEF456", "status": "open", "name": "Open Task", "completion_date": null, "modification_date": "2026-02-13", "creation_date": "2026-02-10", "project": null, "area": null, "tags": []}
+        """
+
+        let result = ThingsURLService.parseTaskStatusResponse(json)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.status, "open")
+        XCTAssertNil(result?.completionDate)
+    }
+
+    func testParseTaskStatusResponseError() {
+        let json = """
+        {"error": "Task not found: XYZ789"}
+        """
+
+        let result = ThingsURLService.parseTaskStatusResponse(json)
+        XCTAssertNil(result, "Should return nil for error responses")
+    }
+
+    func testParseTaskStatusResponseInvalidJSON() {
+        let result = ThingsURLService.parseTaskStatusResponse("not json")
+        XCTAssertNil(result)
+    }
+}

--- a/SeleneChat/Tests/SeleneChatTests/Services/ThreadActivityTests.swift
+++ b/SeleneChat/Tests/SeleneChatTests/Services/ThreadActivityTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import SeleneChat
+
+final class ThreadActivityTests: XCTestCase {
+
+    func testRecordThreadActivityInsertsRow() async throws {
+        let db = DatabaseService.shared
+
+        // Use a known thread ID (thread 1 should exist in test DB)
+        // Record a task_completed activity
+        try await db.recordThreadActivity(threadId: 1, type: "task_completed")
+
+        // Verify by reading back
+        let activities = try await db.getRecentThreadActivity(threadId: 1, days: 1)
+        XCTAssertTrue(activities.contains { $0.activityType == "task_completed" },
+                       "Should have recorded a task_completed activity")
+    }
+
+    func testRecordThreadActivityRejectsInvalidType() async {
+        let db = DatabaseService.shared
+
+        do {
+            try await db.recordThreadActivity(threadId: 1, type: "invalid_type")
+            XCTFail("Should have thrown for invalid activity type")
+        } catch {
+            // Expected — CHECK constraint violation
+        }
+    }
+}

--- a/SeleneChat/Tests/SeleneChatTests/Services/ThreadWorkspacePromptBuilderTests.swift
+++ b/SeleneChat/Tests/SeleneChatTests/Services/ThreadWorkspacePromptBuilderTests.swift
@@ -196,4 +196,40 @@ final class ThreadWorkspacePromptBuilderTests: XCTestCase {
 
         XCTAssertTrue(prompt.contains("Architecture Decisions"), "Follow-up should include thread name")
     }
+
+    // MARK: - What's Next Tests
+
+    func testIsWhatsNextQueryDetectsVariations() {
+        let builder = ThreadWorkspacePromptBuilder()
+
+        XCTAssertTrue(builder.isWhatsNextQuery("what's next"))
+        XCTAssertTrue(builder.isWhatsNextQuery("What's next?"))
+        XCTAssertTrue(builder.isWhatsNextQuery("what should I do next"))
+        XCTAssertTrue(builder.isWhatsNextQuery("What should I work on?"))
+        XCTAssertTrue(builder.isWhatsNextQuery("what do I do now"))
+        XCTAssertFalse(builder.isWhatsNextQuery("break down the auth task"))
+        XCTAssertFalse(builder.isWhatsNextQuery("tell me about this thread"))
+    }
+
+    func testBuildWhatsNextPromptIncludesTaskState() {
+        let thread = Thread.mock(
+            name: "ADHD System",
+            why: "Build tools for executive function",
+            summary: "Phase 1 complete"
+        )
+
+        let openTask = ThreadTask.mock(thingsTaskId: "T1", title: "Research time-blocking")
+        let completedTask = ThreadTask.mock(thingsTaskId: "T2", title: "Write principles doc", completedAt: Date())
+
+        let notes = [
+            Note.mock(id: 1, title: "ADHD Research", content: "Focus on externalization")
+        ]
+
+        let builder = ThreadWorkspacePromptBuilder()
+        let prompt = builder.buildWhatsNextPrompt(thread: thread, notes: notes, tasks: [openTask, completedTask])
+
+        XCTAssertTrue(prompt.contains("Research time-blocking"), "Should include open task")
+        XCTAssertTrue(prompt.contains("Write principles doc"), "Should include completed task")
+        XCTAssertTrue(prompt.contains("recommend"), "Should ask LLM to recommend")
+    }
 }

--- a/SeleneChat/Tests/SeleneChatTests/ViewModels/ThreadWorkspaceChatViewModelTests.swift
+++ b/SeleneChat/Tests/SeleneChatTests/ViewModels/ThreadWorkspaceChatViewModelTests.swift
@@ -241,4 +241,23 @@ final class ThreadWorkspaceChatViewModelTests: XCTestCase {
         XCTAssertEqual(vm.tasks.count, 1)
         XCTAssertEqual(vm.tasks[0].title, "New task")
     }
+
+    // MARK: - What's Next Routing
+
+    func testBuildPromptUsesWhatsNextForMatchingQuery() {
+        let thread = Thread.mock(name: "Test Thread")
+        let vm = ThreadWorkspaceChatViewModel(thread: thread, notes: [], tasks: [])
+
+        let prompt = vm.buildPrompt(for: "what's next?")
+        XCTAssertTrue(prompt.contains("recommend"), "Should use what's next prompt")
+    }
+
+    func testBuildPromptUsesRegularForNonMatchingQuery() {
+        let thread = Thread.mock(name: "Test Thread")
+        let vm = ThreadWorkspaceChatViewModel(thread: thread, notes: [], tasks: [])
+
+        let prompt = vm.buildPrompt(for: "break down the auth task")
+        XCTAssertFalse(prompt.contains("recommend ONE specific task"),
+                       "Should NOT use what's next prompt for regular queries")
+    }
 }

--- a/database/migrations/018_thread_activity.sql
+++ b/database/migrations/018_thread_activity.sql
@@ -1,0 +1,15 @@
+-- 018_thread_activity.sql
+-- Records thread activity events for momentum calculation.
+-- Task completions and note additions are tracked here so
+-- reconsolidate-threads.ts can factor them into momentum scores.
+
+CREATE TABLE IF NOT EXISTS thread_activity (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    thread_id INTEGER NOT NULL,
+    activity_type TEXT NOT NULL CHECK(activity_type IN ('note_added', 'task_completed')),
+    occurred_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (thread_id) REFERENCES threads(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_thread_activity_thread ON thread_activity(thread_id);
+CREATE INDEX IF NOT EXISTS idx_thread_activity_recent ON thread_activity(occurred_at);

--- a/docs/plans/2026-02-06-thread-workspace-design.md
+++ b/docs/plans/2026-02-06-thread-workspace-design.md
@@ -1,7 +1,7 @@
 # Thread Workspace Design
 
 **Date:** 2026-02-06
-**Status:** In Progress
+**Status:** Done
 **Topic:** selenechat
 **Branch:** `feature/thread-workspace`
 

--- a/docs/plans/2026-02-13-thread-workspace-phase3-design.md
+++ b/docs/plans/2026-02-13-thread-workspace-phase3-design.md
@@ -1,7 +1,7 @@
 # Thread Workspace Phase 3: Feedback Loop
 
 **Date:** 2026-02-13
-**Status:** Ready
+**Status:** Done
 **Topic:** selenechat
 
 ---

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -46,7 +46,6 @@ These have acceptance criteria, ADHD check, and scope check. Ready to create a b
 
 | Date | Document | Topic | Notes |
 |------|----------|-------|-------|
-| 2026-02-13 | 2026-02-13-thread-workspace-phase3-design.md | selenechat | Feedback loop: on-demand Things sync, momentum boost, LLM "what's next" |
 
 ---
 
@@ -70,7 +69,6 @@ Branch exists, actively being worked on.
 
 | Date | Document | Branch | Notes |
 |------|----------|--------|-------|
-| 2026-02-06 | 2026-02-06-thread-workspace-design.md | `main` (Phase 1-2 merged) | Phase 3 (feedback loop) remaining |
 
 ---
 
@@ -81,6 +79,8 @@ Branch exists, actively being worked on.
 | 2026-02-12 | 2026-02-12-menu-bar-orchestrator-design.md | 2026-02-13 | Menu bar app with Silver Crystal icon + workflow orchestration |
 | 2026-02-12 | 2026-02-12-voice-memo-transcription-design.md | 2026-02-13 | Whisper.cpp transcription + Selene pipeline integration |
 | 2026-02-12 | 2026-02-12-apple-notes-daily-digest-design.md | 2026-02-13 | Replace iMessage digest with pinned Apple Notes daily note |
+| 2026-02-06 | 2026-02-06-thread-workspace-design.md | 2026-02-13 | Thread workspace: all 3 phases complete (context, actions, feedback loop) |
+| 2026-02-13 | 2026-02-13-thread-workspace-phase3-design.md | 2026-02-13 | Feedback loop: on-demand Things sync, momentum boost, LLM "what's next" |
 | 2026-02-13 | 2026-02-13-morning-briefing-redesign.md | 2026-02-13 | Structured cards, deep context chat, cross-thread connections |
 | 2026-02-13 | 2026-02-13-thread-lifecycle-design.md | 2026-02-13 | Auto archive, split, merge threads — full lifecycle |
 | 2026-02-06 | 2026-02-06-test-environment-isolation-design.md | 2026-02-06 | Complete test isolation with anonymized data |


### PR DESCRIPTION
## Summary

- **On-demand Things sync**: When opening a thread workspace, incomplete tasks are checked against Things via AppleScript — completions flow back into Selene automatically
- **Momentum boost from task completions**: `reconsolidate-threads.ts` now factors `task_completed` events (weight 3x) into momentum scores via new `thread_activity` table
- **LLM "what's next" recommendation**: Typing "what's next" in workspace chat routes to a specialized prompt that considers open/completed tasks and thread context to recommend one specific next action

## Changes

- New `thread_activity` table (migration 018) with indexes
- `DatabaseService`: `recordThreadActivity()`, `getRecentThreadActivity()`, `ensureThreadActivityTable()`
- `ThingsURLService`: `parseTaskStatusResponse()`, `getTaskStatus()`, `syncTaskStatuses()`
- `ThreadWorkspaceView`: `loadData()` calls sync on appear
- `reconsolidate-threads.ts`: momentum formula includes task completions
- `ThreadWorkspacePromptBuilder`: `isWhatsNextQuery()`, `buildWhatsNextPrompt()`
- `ThreadWorkspaceChatViewModel`: `buildPrompt()` routes "what's next" queries

## Test Plan

- [x] 10 new tests (ThreadActivityTests, ThingsSyncTests, PromptBuilder, ChatViewModel)
- [x] 510 total tests pass, 0 regressions
- [ ] Manual: Open thread workspace with linked tasks, verify status syncs from Things
- [ ] Manual: Complete a task in Things, reopen workspace, verify it shows done
- [ ] Manual: Type "what's next" in workspace chat, verify LLM recommends a task
- [ ] Manual: Run `npx ts-node src/workflows/reconsolidate-threads.ts`, verify momentum includes task completions

🤖 Generated with [Claude Code](https://claude.com/claude-code)