### PR TITLE
feat: tiered context compression for LLM context windows

### DIFF
--- a/.claude/PROJECT-STATUS.md
+++ b/.claude/PROJECT-STATUS.md
@@ -22,6 +22,14 @@ Notes form **threads** - lines of thinking that span multiple notes, have underl
 All three "Ready" designs from 2026-02-12 are now implemented and merged. The system has grown significantly: menu bar orchestrator manages workflow scheduling, voice memos are auto-transcribed via whisper.cpp, and the morning briefing got a full redesign with structured cards.
 
 ### Recent Completions
+- **Tiered Context Compression** (2026-02-22) - Lifecycle-based fidelity tiers for LLM context scaling
+  - `ContextBuilder` shared utility — tiered rendering (full/high/summary/skeleton) within token budgets
+  - `distill-essences.ts` — backfills note essences (1-2 sentence distillations) at ~120/hour
+  - `evaluate-fidelity.ts` — daily tier assignment based on age + thread activity
+  - `compile-thread-digests.ts` — thread-level narrative digest compilation
+  - Updated `detect-threads.ts`, `reconsolidate-threads.ts`, `daily-summary.ts` to use ContextBuilder
+  - `/health/compression` endpoint for monitoring tier distribution and backfill progress
+  - Migration 020: `essence`, `fidelity_tier` on `processed_notes`, `thread_digest` on `threads`
 - **Dev Environment Isolation** (2026-02-22) - Full parallel dev environment with 536 fictional notes
   - `~/selene-data-dev/` with separate SQLite, LanceDB, Obsidian vault
   - `SELENE_ENV=development` environment switching via `src/lib/config.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ src/
     ollama.ts         # Ollama API client
     auth.ts           # Bearer token auth middleware
     apns.ts           # APNs push notification client
+    context-builder.ts    # Tiered context assembly utility
   workflows/
     ingest.ts                   # Note ingestion (called by webhook)
     process-llm.ts              # LLM concept extraction
@@ -123,6 +124,9 @@ src/
     daily-summary.ts            # Daily summary generation
     send-digest.ts              # Apple Notes digest delivery
     transcribe-voice-memos.ts   # whisper.cpp voice transcription
+    distill-essences.ts             # Essence backfill + retry
+    evaluate-fidelity.ts            # Fidelity tier assignment (daily)
+    compile-thread-digests.ts       # Thread digest compilation
 
 launchd/
   com.selene.server.plist                  # Webhook server (always running)
@@ -138,6 +142,9 @@ launchd/
   com.selene.send-digest.plist             # Daily at 6am
   com.selene.transcribe-voice-memos.plist  # WatchPaths trigger
   com.selene.dev-process-batch.plist       # Dev: hourly batch processing
+  com.selene.distill-essences.plist          # Every 5 minutes
+  com.selene.evaluate-fidelity.plist         # Daily at 3am
+  com.selene.compile-thread-digests.plist    # Hourly
 ```
 
 **Why this architecture?** See `@.claude/DEVELOPMENT.md` (System Architecture section)
@@ -226,9 +233,15 @@ npx ts-node src/workflows/export-obsidian.ts
 npx ts-node src/workflows/daily-summary.ts
 npx ts-node src/workflows/send-digest.ts
 npx ts-node src/workflows/transcribe-voice-memos.ts
+npx ts-node src/workflows/distill-essences.ts
+npx ts-node src/workflows/evaluate-fidelity.ts
+npx ts-node src/workflows/compile-thread-digests.ts
 
 # View workflow logs
 tail -f logs/selene.log | npx pino-pretty
+
+# Check compression progress
+curl http://localhost:5678/health/compression
 ```
 
 ### Launchd Management

--- a/database/migrations/020_tiered_context_compression.sql
+++ b/database/migrations/020_tiered_context_compression.sql
@@ -1,0 +1,11 @@
+-- 020_tiered_context_compression.sql
+-- Add essence and fidelity tier columns for tiered context compression
+-- Essence: 1-2 sentence LLM distillation of note meaning
+-- Fidelity tier: controls what representation is sent to LLM prompts
+
+ALTER TABLE processed_notes ADD COLUMN essence TEXT;
+ALTER TABLE processed_notes ADD COLUMN essence_at TEXT;
+ALTER TABLE processed_notes ADD COLUMN fidelity_tier TEXT DEFAULT 'full';
+ALTER TABLE processed_notes ADD COLUMN fidelity_evaluated_at TEXT;
+
+ALTER TABLE threads ADD COLUMN thread_digest TEXT;

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -46,7 +46,6 @@ These have acceptance criteria, ADHD check, and scope check. Ready to create a b
 
 | Date | Document | Topic | Notes |
 |------|----------|-------|-------|
-| 2026-02-21 | 2026-02-21-tiered-context-compression-design.md | architecture, llm | Lifecycle-based fidelity tiers for LLM context scaling |
 | 2026-02-15 | 2026-02-15-thinking-partner-upgrade-design.md | selenechat, cloud-ai | Interactive planning + Cloud AI with file workspace (builds on Phase 7.3) |
 | 2026-02-13 | 2026-02-13-kitchenos-selene-integration-design.md | integrations, meal-planning | KitchenOS recipe indexing + conversational meal planning in SeleneChat |
 | 2026-02-13 | 2026-02-13-trmnl-daily-digest-design.md | integrations | Push morning digest to TRMNL e-ink display |
@@ -85,6 +84,7 @@ Branch exists, actively being worked on.
 
 | Date | Document | Completed | Notes |
 |------|----------|-----------|-------|
+| 2026-02-21 | 2026-02-21-tiered-context-compression-design.md | 2026-02-22 | ContextBuilder, 3 new workflows, tier evaluation, essence backfill, health endpoint |
 | 2026-02-21 | 2026-02-21-dev-environment-isolation-design.md | 2026-02-22 | Overmind + Procfile.dev, 536 seed notes, vault export fix, all 9 acceptance criteria pass |
 | 2026-02-14 | 2026-02-14-context-blocks-apple-intelligence-design.md | 2026-02-14 | Chunk-based retrieval, Apple Intelligence LLM, LLM Router, background chunking pipeline |
 | 2026-02-12 | 2026-02-12-menu-bar-orchestrator-design.md | 2026-02-13 | Menu bar app with Silver Crystal icon + workflow orchestration |

--- a/launchd/com.selene.compile-thread-digests.plist
+++ b/launchd/com.selene.compile-thread-digests.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.selene.compile-thread-digests</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/npx</string>
+        <string>ts-node</string>
+        <string>src/workflows/compile-thread-digests.ts</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/chaseeasterling/selene-n8n</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>SELENE_ENV</key>
+        <string>production</string>
+        <key>SELENE_DB_PATH</key>
+        <string>/Users/chaseeasterling/selene-data/selene.db</string>
+    </dict>
+
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/chaseeasterling/selene-n8n/logs/compile-thread-digests.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/chaseeasterling/selene-n8n/logs/compile-thread-digests.error.log</string>
+</dict>
+</plist>

--- a/launchd/com.selene.distill-essences.plist
+++ b/launchd/com.selene.distill-essences.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.selene.distill-essences</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/npx</string>
+        <string>ts-node</string>
+        <string>src/workflows/distill-essences.ts</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/chaseeasterling/selene-n8n</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>SELENE_ENV</key>
+        <string>production</string>
+        <key>SELENE_DB_PATH</key>
+        <string>/Users/chaseeasterling/selene-data/selene.db</string>
+    </dict>
+
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/chaseeasterling/selene-n8n/logs/distill-essences.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/chaseeasterling/selene-n8n/logs/distill-essences.error.log</string>
+</dict>
+</plist>

--- a/launchd/com.selene.evaluate-fidelity.plist
+++ b/launchd/com.selene.evaluate-fidelity.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.selene.evaluate-fidelity</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/npx</string>
+        <string>ts-node</string>
+        <string>src/workflows/evaluate-fidelity.ts</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/chaseeasterling/selene-n8n</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>SELENE_ENV</key>
+        <string>production</string>
+        <key>SELENE_DB_PATH</key>
+        <string>/Users/chaseeasterling/selene-data/selene.db</string>
+    </dict>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/chaseeasterling/selene-n8n/logs/evaluate-fidelity.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/chaseeasterling/selene-n8n/logs/evaluate-fidelity.error.log</string>
+</dict>
+</plist>

--- a/src/lib/context-builder.test.ts
+++ b/src/lib/context-builder.test.ts
@@ -1,0 +1,181 @@
+import assert from 'node:assert';
+import { ContextBuilder, NoteContext, ThreadContext } from './context-builder';
+
+function makeNote(overrides: Partial<NoteContext> = {}): NoteContext {
+  return {
+    id: 1,
+    title: 'Test Note',
+    content: 'This is the full content of the note.',
+    essence: 'Core insight of the note.',
+    primary_theme: 'testing',
+    concepts: JSON.stringify(['concept-a', 'concept-b', 'concept-c']),
+    fidelity_tier: 'full',
+    ...overrides,
+  };
+}
+
+function makeThread(overrides: Partial<ThreadContext> = {}): ThreadContext {
+  return {
+    id: 1,
+    name: 'ADHD Strategies',
+    thread_digest: 'A digest summarizing the thread.',
+    summary: 'Thread summary text.',
+    why: 'To improve focus.',
+    note_count: 5,
+    ...overrides,
+  };
+}
+
+let passed = 0;
+
+// Test 1: Empty builder returns empty string
+{
+  const cb = new ContextBuilder(1000);
+  assert.strictEqual(cb.build(), '', 'Empty builder should return empty string');
+  passed++;
+  console.log('PASS 1: Empty builder returns empty string');
+}
+
+// Test 2: Full tier renders title + content
+{
+  const cb = new ContextBuilder(1000);
+  const note = makeNote({ fidelity_tier: 'full' });
+  cb.addNote(note);
+  const result = cb.build();
+  assert.ok(result.includes('--- Test Note ---'), 'Should include title');
+  assert.ok(result.includes('This is the full content of the note.'), 'Should include content');
+  assert.ok(!result.includes('[Essence]'), 'Full tier should not include [Essence] label');
+  passed++;
+  console.log('PASS 2: Full tier renders title + content');
+}
+
+// Test 3: High tier renders title + essence + content
+{
+  const cb = new ContextBuilder(1000);
+  const note = makeNote({ fidelity_tier: 'high' });
+  cb.addNote(note);
+  const result = cb.build();
+  assert.ok(result.includes('--- Test Note ---'), 'Should include title');
+  assert.ok(result.includes('[Essence] Core insight of the note.'), 'Should include essence');
+  assert.ok(result.includes('This is the full content of the note.'), 'Should include content');
+  passed++;
+  console.log('PASS 3: High tier renders title + essence + content');
+}
+
+// Test 4: Summary tier renders title + essence + themes (no content)
+{
+  const cb = new ContextBuilder(1000);
+  const note = makeNote({ fidelity_tier: 'summary' });
+  cb.addNote(note);
+  const result = cb.build();
+  assert.ok(result.includes('--- Test Note [testing] ---'), 'Should include title with theme');
+  assert.ok(result.includes('Core insight of the note.'), 'Should include essence');
+  assert.ok(!result.includes('This is the full content of the note.'), 'Summary should NOT include full content');
+  passed++;
+  console.log('PASS 4: Summary tier renders title + essence + themes (no content)');
+}
+
+// Test 5: Skeleton tier renders title + theme only
+{
+  const cb = new ContextBuilder(1000);
+  const note = makeNote({ fidelity_tier: 'skeleton' });
+  cb.addNote(note);
+  const result = cb.build();
+  assert.strictEqual(result, '- Test Note [testing]', 'Skeleton should be compact title + theme');
+  passed++;
+  console.log('PASS 5: Skeleton tier renders title + theme only');
+}
+
+// Test 6: Token budget enforcement - stops adding notes when full
+{
+  // Note 1 renders as "--- Note 1 ---\nContent of note one." = 36 chars
+  // Budget of 10 tokens = 40 chars. Only first note fits.
+  const cb = new ContextBuilder(10);
+  const note1 = makeNote({ id: 1, title: 'Note 1', content: 'Content of note one.', fidelity_tier: 'full' });
+  const note2 = makeNote({ id: 2, title: 'Note 2', content: 'Content of note two.', fidelity_tier: 'full' });
+
+  cb.addNote(note1);
+  cb.addNote(note2);
+
+  const result = cb.build();
+  // First note (36 chars) fits within 40 char budget; second (36 chars) would push to 72, dropped
+  assert.ok(result.includes('Note 1'), 'First note should be included');
+  assert.ok(!result.includes('Note 2'), 'Second note should be dropped (budget exceeded)');
+  assert.ok(cb.remainingTokens() >= 0, 'Remaining tokens should be non-negative');
+  assert.ok(cb.remainingTokens() <= 10, 'Remaining tokens should be small');
+  passed++;
+  console.log('PASS 6: Token budget enforcement');
+}
+
+// Test 7: Fallback chain - missing essence falls back to concepts then truncated content
+{
+  // 7a: Missing essence, has concepts -> summary shows concepts
+  const cb1 = new ContextBuilder(1000);
+  const noteWithConcepts = makeNote({
+    fidelity_tier: 'summary',
+    essence: null,
+    concepts: JSON.stringify(['focus', 'attention', 'routine']),
+  });
+  cb1.addNote(noteWithConcepts);
+  const result1 = cb1.build();
+  assert.ok(result1.includes('Concepts: focus, attention, routine'), 'Should fall back to concepts');
+
+  // 7b: Missing essence AND concepts -> truncated content
+  const cb2 = new ContextBuilder(1000);
+  const longContent = 'A'.repeat(200);
+  const noteNoEssenceNoConcepts = makeNote({
+    fidelity_tier: 'summary',
+    essence: null,
+    concepts: null,
+    content: longContent,
+  });
+  cb2.addNote(noteNoEssenceNoConcepts);
+  const result2 = cb2.build();
+  assert.ok(result2.includes('A'.repeat(150) + '...'), 'Should fall back to truncated content');
+  assert.ok(!result2.includes('A'.repeat(200)), 'Should NOT include full 200-char content');
+
+  passed++;
+  console.log('PASS 7: Fallback chain (essence -> concepts -> truncated content)');
+}
+
+// Test 8: Thread digest rendering
+{
+  const cb = new ContextBuilder(1000);
+  const thread = makeThread();
+  cb.addThread(thread);
+  const result = cb.build();
+  assert.ok(result.includes('=== Thread: ADHD Strategies (5 notes) ==='), 'Should include thread header');
+  assert.ok(result.includes('A digest summarizing the thread.'), 'Should include digest');
+  // When digest is present, summary should NOT appear (digest takes priority)
+  assert.ok(!result.includes('Thread summary text.'), 'Should NOT include summary when digest exists');
+  passed++;
+  console.log('PASS 8: Thread digest rendering');
+}
+
+// Test 9: Thread without digest falls back to summary
+{
+  const cb = new ContextBuilder(1000);
+  const thread = makeThread({ thread_digest: null });
+  cb.addThread(thread);
+  const result = cb.build();
+  assert.ok(result.includes('=== Thread: ADHD Strategies (5 notes) ==='), 'Should include thread header');
+  assert.ok(result.includes('Thread summary text.'), 'Should fall back to summary');
+  assert.ok(result.includes('Motivation: To improve focus.'), 'Should include why');
+  passed++;
+  console.log('PASS 9: Thread without digest falls back to summary');
+}
+
+// Test 10: addFullText always uses full content regardless of tier
+{
+  const cb = new ContextBuilder(1000);
+  const note = makeNote({ fidelity_tier: 'skeleton' }); // tier is skeleton but addFullText should override
+  cb.addFullText(note);
+  const result = cb.build();
+  assert.ok(result.includes('--- Test Note ---'), 'Should include title');
+  assert.ok(result.includes('This is the full content of the note.'), 'Should include full content even though tier is skeleton');
+  assert.ok(!result.startsWith('- Test Note'), 'Should NOT use skeleton format');
+  passed++;
+  console.log('PASS 10: addFullText always uses full content regardless of tier');
+}
+
+console.log(`\nAll ${passed}/10 tests passed.`);

--- a/src/lib/context-builder.ts
+++ b/src/lib/context-builder.ts
@@ -20,7 +20,7 @@ export interface NoteContext {
   essence: string | null;
   primary_theme: string | null;
   concepts: string | null; // JSON array string
-  fidelity_tier: string;
+  fidelity_tier: FidelityTier;
 }
 
 export interface ThreadContext {
@@ -46,7 +46,7 @@ export class ContextBuilder {
 
   /** Add a note rendered at its fidelity tier. */
   addNote(note: NoteContext): this {
-    const block = this.renderNote(note, note.fidelity_tier as FidelityTier);
+    const block = this.renderNote(note, note.fidelity_tier);
     return this.appendBlock(block);
   }
 
@@ -73,11 +73,12 @@ export class ContextBuilder {
   }
 
   private appendBlock(block: string): this {
-    if (this.usedChars + block.length > this.budgetChars) {
+    const separatorCost = this.blocks.length > 0 ? 2 : 0; // '\n\n' between blocks
+    if (this.usedChars + block.length + separatorCost > this.budgetChars) {
       return this;
     }
     this.blocks.push(block);
-    this.usedChars += block.length;
+    this.usedChars += block.length + separatorCost;
     return this;
   }
 

--- a/src/lib/context-builder.ts
+++ b/src/lib/context-builder.ts
@@ -1,0 +1,137 @@
+/**
+ * ContextBuilder: Assembles tiered note/thread context within a token budget.
+ *
+ * Tier rendering rules:
+ *   full     -> title + full content
+ *   high     -> title + essence + full content
+ *   summary  -> title + essence + themes (no content)
+ *   skeleton -> title + primary_theme
+ *
+ * Fallback: if essence is missing, uses concepts -> truncated content (150 chars)
+ * Token estimation: character count / 4 (no external tokenizer)
+ */
+
+export type FidelityTier = 'full' | 'high' | 'summary' | 'skeleton';
+
+export interface NoteContext {
+  id: number;
+  title: string;
+  content: string;
+  essence: string | null;
+  primary_theme: string | null;
+  concepts: string | null; // JSON array string
+  fidelity_tier: string;
+}
+
+export interface ThreadContext {
+  id: number;
+  name: string;
+  thread_digest: string | null;
+  summary: string | null;
+  why: string | null;
+  note_count: number;
+}
+
+const CHARS_PER_TOKEN = 4;
+const FALLBACK_CONTENT_LENGTH = 150;
+
+export class ContextBuilder {
+  private budgetChars: number;
+  private usedChars: number = 0;
+  private blocks: string[] = [];
+
+  constructor(budgetTokens: number) {
+    this.budgetChars = budgetTokens * CHARS_PER_TOKEN;
+  }
+
+  /** Add a note rendered at its fidelity tier. */
+  addNote(note: NoteContext): this {
+    const block = this.renderNote(note, note.fidelity_tier as FidelityTier);
+    return this.appendBlock(block);
+  }
+
+  /** Add a note always rendered at full fidelity, regardless of tier. */
+  addFullText(note: NoteContext): this {
+    const block = this.renderNote(note, 'full');
+    return this.appendBlock(block);
+  }
+
+  /** Add a thread rendered with digest or summary fallback. */
+  addThread(thread: ThreadContext): this {
+    const block = this.renderThread(thread);
+    return this.appendBlock(block);
+  }
+
+  /** Get remaining token budget. */
+  remainingTokens(): number {
+    return Math.floor((this.budgetChars - this.usedChars) / CHARS_PER_TOKEN);
+  }
+
+  /** Build the final context string. */
+  build(): string {
+    return this.blocks.join('\n\n');
+  }
+
+  private appendBlock(block: string): this {
+    if (this.usedChars + block.length > this.budgetChars) {
+      return this;
+    }
+    this.blocks.push(block);
+    this.usedChars += block.length;
+    return this;
+  }
+
+  private renderNote(note: NoteContext, tier: FidelityTier): string {
+    switch (tier) {
+      case 'full':
+        return `--- ${note.title} ---\n${note.content}`;
+
+      case 'high':
+        return note.essence
+          ? `--- ${note.title} ---\n[Essence] ${note.essence}\n${note.content}`
+          : `--- ${note.title} ---\n${note.content}`;
+
+      case 'summary':
+        if (note.essence) {
+          const theme = note.primary_theme ? ` [${note.primary_theme}]` : '';
+          return `--- ${note.title}${theme} ---\n${note.essence}`;
+        }
+        return `--- ${note.title} ---\n${this.getFallbackPreview(note)}`;
+
+      case 'skeleton':
+        return `- ${note.title} [${note.primary_theme || 'unthemed'}]`;
+
+      default:
+        return `--- ${note.title} ---\n${note.content}`;
+    }
+  }
+
+  private renderThread(thread: ThreadContext): string {
+    const lines: string[] = [`=== Thread: ${thread.name} (${thread.note_count} notes) ===`];
+
+    if (thread.thread_digest) {
+      lines.push(thread.thread_digest);
+    } else if (thread.summary) {
+      lines.push(thread.summary);
+      if (thread.why) {
+        lines.push(`Motivation: ${thread.why}`);
+      }
+    }
+
+    return lines.join('\n');
+  }
+
+  private getFallbackPreview(note: NoteContext): string {
+    if (note.concepts) {
+      try {
+        const conceptList = JSON.parse(note.concepts) as string[];
+        if (conceptList.length > 0) {
+          return `Concepts: ${conceptList.slice(0, 5).join(', ')}`;
+        }
+      } catch {
+        // Fall through
+      }
+    }
+    return note.content.slice(0, FALLBACK_CONTENT_LENGTH) + (note.content.length > FALLBACK_CONTENT_LENGTH ? '...' : '');
+  }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -31,3 +31,4 @@ export {
   type SimilarNote,
   type SearchOptions,
 } from './lancedb';
+export { ContextBuilder, type NoteContext, type ThreadContext, type FidelityTier } from './context-builder';

--- a/src/workflows/compile-thread-digests.test.ts
+++ b/src/workflows/compile-thread-digests.test.ts
@@ -1,0 +1,44 @@
+import assert from 'assert';
+
+async function runTests() {
+  const { buildDigestPrompt } = await import('./compile-thread-digests');
+
+  // Test 1: Prompt includes thread name, summary, and note essences
+  {
+    const prompt = buildDigestPrompt(
+      'ADHD Systems',
+      'Exploring ADHD coping strategies.',
+      'Need structure without rigidity.',
+      [
+        { essence: 'Tried time-blocking but found it too rigid.' },
+        { essence: 'Body doubling works well for deep work sessions.' },
+      ]
+    );
+    assert.ok(prompt.includes('ADHD Systems'), 'should include thread name');
+    assert.ok(prompt.includes('Exploring ADHD'), 'should include summary');
+    assert.ok(prompt.includes('time-blocking'), 'should include first essence');
+    assert.ok(prompt.includes('Body doubling'), 'should include second essence');
+    console.log('  \u2713 digest prompt includes all context');
+  }
+
+  // Test 2: Prompt handles null summary and why
+  {
+    const prompt = buildDigestPrompt(
+      'New Thread',
+      null,
+      null,
+      [{ essence: 'First note essence.' }]
+    );
+    assert.ok(prompt.includes('New Thread'), 'should include name');
+    assert.ok(prompt.includes('(none)'), 'should show (none) for null fields');
+    assert.ok(prompt.includes('First note essence'), 'should include essence');
+    console.log('  \u2713 digest prompt handles null summary and why');
+  }
+
+  console.log('\nAll compile-thread-digests tests passed!');
+}
+
+runTests().catch((err) => {
+  console.error('Tests failed:', err);
+  process.exit(1);
+});

--- a/src/workflows/compile-thread-digests.ts
+++ b/src/workflows/compile-thread-digests.ts
@@ -1,0 +1,139 @@
+import { createWorkflowLogger, db, generate, isAvailable } from '../lib';
+import type { WorkflowResult } from '../types';
+
+const log = createWorkflowLogger('compile-thread-digests');
+
+interface ThreadForDigest {
+  id: number;
+  name: string;
+  summary: string | null;
+  why: string | null;
+  note_count: number;
+}
+
+interface NoteEssence {
+  essence: string;
+}
+
+/**
+ * Build the LLM prompt for thread digest compilation.
+ */
+export function buildDigestPrompt(
+  name: string,
+  summary: string | null,
+  why: string | null,
+  essences: NoteEssence[]
+): string {
+  const essenceList = essences
+    .map((e, i) => `${i + 1}. ${e.essence}`)
+    .join('\n');
+
+  return `Thread: ${name}
+Summary: ${summary || '(none)'}
+Motivation: ${why || '(none)'}
+
+Note essences (distilled meanings):
+${essenceList}
+
+Write a single paragraph (3-5 sentences) capturing this thread's arc: what started it, how it evolved, and where it stands now. Write in present tense. Be specific, not generic.
+
+Paragraph:`;
+}
+
+export async function compileThreadDigests(): Promise<WorkflowResult> {
+  log.info('Starting thread digest compilation');
+
+  if (!(await isAvailable())) {
+    log.error('Ollama is not available');
+    return { processed: 0, errors: 0, details: [] };
+  }
+
+  // Find active threads with 10+ notes where digest is stale or missing
+  const threads = db
+    .prepare(
+      `SELECT t.id, t.name, t.summary, t.why,
+              (SELECT COUNT(*) FROM thread_notes tn WHERE tn.thread_id = t.id) as note_count
+       FROM threads t
+       WHERE t.status = 'active'
+         AND (SELECT COUNT(*) FROM thread_notes tn WHERE tn.thread_id = t.id) >= 10
+         AND (t.thread_digest IS NULL
+              OR t.updated_at > COALESCE(
+                (SELECT MAX(pn.essence_at) FROM processed_notes pn
+                 JOIN thread_notes tn2 ON pn.raw_note_id = tn2.raw_note_id
+                 WHERE tn2.thread_id = t.id AND pn.essence IS NOT NULL),
+                '1970-01-01'))
+       ORDER BY t.momentum_score DESC NULLS LAST`
+    )
+    .all() as ThreadForDigest[];
+
+  log.info({ threadCount: threads.length }, 'Threads needing digest compilation');
+
+  const result: WorkflowResult = {
+    processed: 0,
+    errors: 0,
+    details: [],
+  };
+
+  for (const thread of threads) {
+    try {
+      const essences = db
+        .prepare(
+          `SELECT pn.essence
+           FROM processed_notes pn
+           JOIN thread_notes tn ON pn.raw_note_id = tn.raw_note_id
+           WHERE tn.thread_id = ? AND pn.essence IS NOT NULL
+           ORDER BY pn.essence_at DESC`
+        )
+        .all(thread.id) as NoteEssence[];
+
+      if (essences.length < 5) {
+        log.info(
+          { threadId: thread.id, essenceCount: essences.length },
+          'Not enough essences yet, skipping'
+        );
+        continue;
+      }
+
+      const prompt = buildDigestPrompt(thread.name, thread.summary, thread.why, essences);
+      const response = await generate(prompt);
+      const digest = response.trim();
+
+      if (!digest || digest.length < 30) {
+        log.warn({ threadId: thread.id }, 'Digest too short, skipping');
+        result.errors++;
+        result.details.push({ id: thread.id, success: false, error: 'Digest too short' });
+        continue;
+      }
+
+      db.prepare(`UPDATE threads SET thread_digest = ? WHERE id = ?`).run(digest, thread.id);
+
+      log.info({ threadId: thread.id, digestLength: digest.length }, 'Thread digest compiled');
+      result.processed++;
+      result.details.push({ id: thread.id, success: true });
+    } catch (err) {
+      const error = err as Error;
+      log.error({ threadId: thread.id, err: error }, 'Failed to compile digest');
+      result.errors++;
+      result.details.push({ id: thread.id, success: false, error: error.message });
+    }
+  }
+
+  log.info(
+    { processed: result.processed, errors: result.errors },
+    'Thread digest compilation complete'
+  );
+  return result;
+}
+
+// CLI entry point
+if (require.main === module) {
+  compileThreadDigests()
+    .then((result) => {
+      console.log('Compile-thread-digests complete:', result);
+      process.exit(result.errors > 0 ? 1 : 0);
+    })
+    .catch((err) => {
+      console.error('Compile-thread-digests failed:', err);
+      process.exit(1);
+    });
+}

--- a/src/workflows/detect-threads.ts
+++ b/src/workflows/detect-threads.ts
@@ -1,4 +1,5 @@
 import { createWorkflowLogger, db, generate, embed, searchSimilarNotes, getIndexedNoteIds, ContextBuilder } from '../lib';
+import type { FidelityTier } from '../lib/context-builder';
 import { normalizeThreadName } from '../lib/strings';
 import { notifyNewThread } from '../lib/apns';
 import type { WorkflowResult } from '../types';
@@ -9,8 +10,6 @@ const log = createWorkflowLogger('detect-threads');
 // Tuned via US-046: 0.65 provides best balance between cluster detection and over-merging
 const DEFAULT_SIMILARITY_THRESHOLD = 0.65;
 const MIN_CLUSTER_SIZE = 3;
-const MAX_NOTES_PER_SYNTHESIS = 15;
-
 // Thread assignment configuration
 // L2 distance threshold - based on observed data: median ~288, 75th percentile ~346
 const MAX_ASSIGNMENT_DISTANCE = 350; // L2 distance threshold for thread assignment
@@ -26,7 +25,7 @@ interface NoteRecord {
   essence: string | null;
   primary_theme: string | null;
   concepts: string | null;
-  fidelity_tier: string;
+  fidelity_tier: FidelityTier;
 }
 
 interface AssociationRecord {

--- a/src/workflows/detect-threads.ts
+++ b/src/workflows/detect-threads.ts
@@ -1,4 +1,4 @@
-import { createWorkflowLogger, db, generate, embed, searchSimilarNotes, getIndexedNoteIds } from '../lib';
+import { createWorkflowLogger, db, generate, embed, searchSimilarNotes, getIndexedNoteIds, ContextBuilder } from '../lib';
 import { normalizeThreadName } from '../lib/strings';
 import { notifyNewThread } from '../lib/apns';
 import type { WorkflowResult } from '../types';
@@ -23,6 +23,10 @@ interface NoteRecord {
   title: string;
   content: string;
   created_at: string;
+  essence: string | null;
+  primary_theme: string | null;
+  concepts: string | null;
+  fidelity_tier: string;
 }
 
 interface AssociationRecord {
@@ -296,10 +300,13 @@ function getNoteContent(noteIds: number[]): NoteRecord[] {
   const placeholders = noteIds.map(() => '?').join(',');
   return db
     .prepare(
-      `SELECT id, title, content, created_at
-       FROM raw_notes
-       WHERE id IN (${placeholders})
-       ORDER BY created_at ASC`
+      `SELECT rn.id, rn.title, rn.content, rn.created_at,
+              pn.essence, pn.primary_theme, pn.concepts,
+              COALESCE(pn.fidelity_tier, 'full') as fidelity_tier
+       FROM raw_notes rn
+       LEFT JOIN processed_notes pn ON rn.id = pn.raw_note_id
+       WHERE rn.id IN (${placeholders})
+       ORDER BY rn.created_at ASC`
     )
     .all(...noteIds) as NoteRecord[];
 }
@@ -308,10 +315,21 @@ function getNoteContent(noteIds: number[]): NoteRecord[] {
  * Build LLM prompt for thread synthesis
  */
 function buildSynthesisPrompt(notes: NoteRecord[]): string {
-  const noteTexts = notes
-    .slice(0, MAX_NOTES_PER_SYNTHESIS)
-    .map((n, i) => `--- Note ${i + 1} (${n.created_at}) ---\nTitle: ${n.title}\n${n.content}`)
-    .join('\n\n');
+  const builder = new ContextBuilder(3000);
+
+  for (const note of notes) {
+    builder.addNote({
+      id: note.id,
+      title: `${note.title} (${note.created_at})`,
+      content: note.content,
+      essence: note.essence,
+      primary_theme: note.primary_theme,
+      concepts: note.concepts,
+      fidelity_tier: note.fidelity_tier,
+    });
+  }
+
+  const noteTexts = builder.build();
 
   return `These notes were written over time by the same person. They cluster together based on semantic similarity.
 

--- a/src/workflows/distill-essences.test.ts
+++ b/src/workflows/distill-essences.test.ts
@@ -1,0 +1,18 @@
+import assert from 'assert';
+
+async function runTests() {
+  const { getNotesNeedingEssence } = await import('./distill-essences');
+
+  // Test 1: Function exists and is callable
+  {
+    assert.strictEqual(typeof getNotesNeedingEssence, 'function');
+    console.log('  ✓ getNotesNeedingEssence is exported');
+  }
+
+  console.log('\nAll distill-essences tests passed!');
+}
+
+runTests().catch((err) => {
+  console.error('Tests failed:', err);
+  process.exit(1);
+});

--- a/src/workflows/distill-essences.ts
+++ b/src/workflows/distill-essences.ts
@@ -1,0 +1,106 @@
+import { createWorkflowLogger, db, generate, isAvailable } from '../lib';
+import { buildEssencePrompt } from './process-llm';
+import type { WorkflowResult } from '../types';
+
+const log = createWorkflowLogger('distill-essences');
+
+interface NoteForEssence {
+  raw_note_id: number;
+  title: string;
+  content: string;
+  concepts: string | null;
+  primary_theme: string | null;
+}
+
+/**
+ * Get processed notes that still need an essence computed.
+ */
+export function getNotesNeedingEssence(limit = 10): NoteForEssence[] {
+  return db
+    .prepare(
+      `SELECT pn.raw_note_id, rn.title, rn.content, pn.concepts, pn.primary_theme
+       FROM processed_notes pn
+       JOIN raw_notes rn ON pn.raw_note_id = rn.id
+       WHERE pn.essence IS NULL
+         AND rn.test_run IS NULL
+       ORDER BY rn.created_at DESC
+       LIMIT ?`
+    )
+    .all(limit) as NoteForEssence[];
+}
+
+export async function distillEssences(limit = 10): Promise<WorkflowResult> {
+  log.info({ limit }, 'Starting essence distillation run');
+
+  if (!(await isAvailable())) {
+    log.error('Ollama is not available');
+    return { processed: 0, errors: 0, details: [] };
+  }
+
+  const notes = getNotesNeedingEssence(limit);
+  log.info({ noteCount: notes.length }, 'Found notes needing essence');
+
+  if (notes.length === 0) {
+    log.info('All notes have essences — nothing to do');
+    return { processed: 0, errors: 0, details: [] };
+  }
+
+  const result: WorkflowResult = {
+    processed: 0,
+    errors: 0,
+    details: [],
+  };
+
+  for (const note of notes) {
+    try {
+      const prompt = buildEssencePrompt(
+        note.title,
+        note.content,
+        note.concepts,
+        note.primary_theme
+      );
+
+      const response = await generate(prompt);
+      const essence = response.trim();
+
+      if (!essence || essence.length <= 10) {
+        log.warn({ noteId: note.raw_note_id }, 'Essence too short, skipping');
+        result.errors++;
+        result.details.push({ id: note.raw_note_id, success: false, error: 'Essence too short' });
+        continue;
+      }
+
+      db.prepare(
+        `UPDATE processed_notes SET essence = ?, essence_at = ? WHERE raw_note_id = ?`
+      ).run(essence, new Date().toISOString(), note.raw_note_id);
+
+      log.info({ noteId: note.raw_note_id, essenceLength: essence.length }, 'Essence computed');
+      result.processed++;
+      result.details.push({ id: note.raw_note_id, success: true });
+    } catch (err) {
+      const error = err as Error;
+      log.error({ noteId: note.raw_note_id, err: error }, 'Failed to compute essence');
+      result.errors++;
+      result.details.push({ id: note.raw_note_id, success: false, error: error.message });
+    }
+  }
+
+  log.info(
+    { processed: result.processed, errors: result.errors },
+    'Essence distillation complete'
+  );
+  return result;
+}
+
+// CLI entry point
+if (require.main === module) {
+  distillEssences()
+    .then((result) => {
+      console.log('Distill-essences complete:', result);
+      process.exit(result.errors > 0 ? 1 : 0);
+    })
+    .catch((err) => {
+      console.error('Distill-essences failed:', err);
+      process.exit(1);
+    });
+}

--- a/src/workflows/evaluate-fidelity.test.ts
+++ b/src/workflows/evaluate-fidelity.test.ts
@@ -1,0 +1,61 @@
+import assert from 'assert';
+
+async function runTests() {
+  const { computeTier } = await import('./evaluate-fidelity');
+
+  // Test 1: Fresh note (< 7 days) → full
+  {
+    const tier = computeTier({ ageDays: 3, hasEssence: false, threadStatus: 'active', lastAccessDays: 1 });
+    assert.strictEqual(tier, 'full');
+    console.log('  ✓ fresh note → full');
+  }
+
+  // Test 2: Warm note (30 days, active thread) → high
+  {
+    const tier = computeTier({ ageDays: 30, hasEssence: true, threadStatus: 'active', lastAccessDays: 5 });
+    assert.strictEqual(tier, 'high');
+    console.log('  ✓ warm active thread note → high');
+  }
+
+  // Test 3: Warm note without essence stays full
+  {
+    const tier = computeTier({ ageDays: 30, hasEssence: false, threadStatus: 'active', lastAccessDays: 5 });
+    assert.strictEqual(tier, 'full');
+    console.log('  ✓ warm note without essence stays full');
+  }
+
+  // Test 4: Cool note (120 days, archived, has essence) → summary
+  {
+    const tier = computeTier({ ageDays: 120, hasEssence: true, threadStatus: 'archived', lastAccessDays: 100 });
+    assert.strictEqual(tier, 'summary');
+    console.log('  ✓ cool inactive note → summary');
+  }
+
+  // Test 5: Cold note (200 days, archived, no access) → skeleton
+  {
+    const tier = computeTier({ ageDays: 200, hasEssence: true, threadStatus: 'archived', lastAccessDays: 200 });
+    assert.strictEqual(tier, 'skeleton');
+    console.log('  ✓ cold archived note → skeleton');
+  }
+
+  // Test 6: Old note in active thread → high (rehydration)
+  {
+    const tier = computeTier({ ageDays: 200, hasEssence: true, threadStatus: 'active', lastAccessDays: 2 });
+    assert.strictEqual(tier, 'high');
+    console.log('  ✓ old note in active thread → high (rehydration)');
+  }
+
+  // Test 7: Cannot demote without essence
+  {
+    const tier = computeTier({ ageDays: 200, hasEssence: false, threadStatus: 'archived', lastAccessDays: 200 });
+    assert.strictEqual(tier, 'full');
+    console.log('  ✓ cannot demote without essence');
+  }
+
+  console.log('\nAll evaluate-fidelity tests passed!');
+}
+
+runTests().catch((err) => {
+  console.error('Tests failed:', err);
+  process.exit(1);
+});

--- a/src/workflows/evaluate-fidelity.test.ts
+++ b/src/workflows/evaluate-fidelity.test.ts
@@ -5,51 +5,58 @@ async function runTests() {
 
   // Test 1: Fresh note (< 7 days) → full
   {
-    const tier = computeTier({ ageDays: 3, hasEssence: false, threadStatus: 'active', lastAccessDays: 1 });
+    const tier = computeTier({ ageDays: 3, hasEssence: false, threadStatus: 'active' });
     assert.strictEqual(tier, 'full');
     console.log('  ✓ fresh note → full');
   }
 
   // Test 2: Warm note (30 days, active thread) → high
   {
-    const tier = computeTier({ ageDays: 30, hasEssence: true, threadStatus: 'active', lastAccessDays: 5 });
+    const tier = computeTier({ ageDays: 30, hasEssence: true, threadStatus: 'active' });
     assert.strictEqual(tier, 'high');
     console.log('  ✓ warm active thread note → high');
   }
 
   // Test 3: Warm note without essence stays full
   {
-    const tier = computeTier({ ageDays: 30, hasEssence: false, threadStatus: 'active', lastAccessDays: 5 });
+    const tier = computeTier({ ageDays: 30, hasEssence: false, threadStatus: 'active' });
     assert.strictEqual(tier, 'full');
     console.log('  ✓ warm note without essence stays full');
   }
 
   // Test 4: Cool note (120 days, archived, has essence) → summary
   {
-    const tier = computeTier({ ageDays: 120, hasEssence: true, threadStatus: 'archived', lastAccessDays: 100 });
+    const tier = computeTier({ ageDays: 120, hasEssence: true, threadStatus: 'archived' });
     assert.strictEqual(tier, 'summary');
     console.log('  ✓ cool inactive note → summary');
   }
 
-  // Test 5: Cold note (200 days, archived, no access) → skeleton
+  // Test 5: Cold note (200 days, archived) → skeleton
   {
-    const tier = computeTier({ ageDays: 200, hasEssence: true, threadStatus: 'archived', lastAccessDays: 200 });
+    const tier = computeTier({ ageDays: 200, hasEssence: true, threadStatus: 'archived' });
     assert.strictEqual(tier, 'skeleton');
     console.log('  ✓ cold archived note → skeleton');
   }
 
   // Test 6: Old note in active thread → high (rehydration)
   {
-    const tier = computeTier({ ageDays: 200, hasEssence: true, threadStatus: 'active', lastAccessDays: 2 });
+    const tier = computeTier({ ageDays: 200, hasEssence: true, threadStatus: 'active' });
     assert.strictEqual(tier, 'high');
     console.log('  ✓ old note in active thread → high (rehydration)');
   }
 
   // Test 7: Cannot demote without essence
   {
-    const tier = computeTier({ ageDays: 200, hasEssence: false, threadStatus: 'archived', lastAccessDays: 200 });
+    const tier = computeTier({ ageDays: 200, hasEssence: false, threadStatus: 'archived' });
     assert.strictEqual(tier, 'full');
     console.log('  ✓ cannot demote without essence');
+  }
+
+  // Test 8: Note not in any thread (null status), old with essence → summary
+  {
+    const tier = computeTier({ ageDays: 120, hasEssence: true, threadStatus: null });
+    assert.strictEqual(tier, 'summary');
+    console.log('  ✓ threadless note 120 days old → summary');
   }
 
   console.log('\nAll evaluate-fidelity tests passed!');

--- a/src/workflows/evaluate-fidelity.ts
+++ b/src/workflows/evaluate-fidelity.ts
@@ -1,0 +1,125 @@
+import { createWorkflowLogger, db } from '../lib';
+import type { WorkflowResult } from '../types';
+
+const log = createWorkflowLogger('evaluate-fidelity');
+
+interface TierInput {
+  ageDays: number;
+  hasEssence: boolean;
+  threadStatus: string | null;
+  lastAccessDays: number;
+}
+
+/**
+ * Pure function: compute the fidelity tier for a note based on age and activity.
+ *
+ * Rules:
+ *   FULL:     age < 7 days
+ *   HIGH:     age < 90 days OR in active thread (requires essence)
+ *   SUMMARY:  age >= 90 days AND thread inactive/archived (requires essence)
+ *   SKELETON: thread archived AND no access in 180 days (requires essence)
+ *
+ * Guard: cannot demote below 'full' without an essence.
+ */
+export function computeTier(input: TierInput): string {
+  const { ageDays, hasEssence, threadStatus, lastAccessDays } = input;
+
+  // Fresh notes are always full
+  if (ageDays < 7) return 'full';
+
+  // Guard: no demotion without essence
+  if (!hasEssence) return 'full';
+
+  // Active thread keeps notes at high regardless of age
+  if (threadStatus === 'active') return 'high';
+
+  // Warm period
+  if (ageDays < 90) return 'high';
+
+  // Cold: archived + untouched 180+ days
+  if (threadStatus === 'archived' && lastAccessDays >= 180) return 'skeleton';
+
+  // Cool: 90+ days, inactive/archived
+  return 'summary';
+}
+
+interface NoteForEvaluation {
+  raw_note_id: number;
+  fidelity_tier: string;
+  essence: string | null;
+  age_days: number;
+  thread_status: string | null;
+}
+
+export async function evaluateFidelity(): Promise<WorkflowResult> {
+  log.info('Starting fidelity evaluation');
+
+  const notes = db
+    .prepare(
+      `SELECT
+         pn.raw_note_id,
+         pn.fidelity_tier,
+         pn.essence,
+         CAST(julianday('now') - julianday(rn.created_at) AS INTEGER) as age_days,
+         t.status as thread_status
+       FROM processed_notes pn
+       JOIN raw_notes rn ON pn.raw_note_id = rn.id
+       LEFT JOIN thread_notes tn ON rn.id = tn.raw_note_id
+       LEFT JOIN threads t ON tn.thread_id = t.id
+       WHERE pn.fidelity_tier != 'skeleton'
+         AND rn.test_run IS NULL
+       GROUP BY pn.raw_note_id`
+    )
+    .all() as NoteForEvaluation[];
+
+  log.info({ noteCount: notes.length }, 'Notes to evaluate');
+
+  const result: WorkflowResult = {
+    processed: 0,
+    errors: 0,
+    details: [],
+  };
+
+  const now = new Date().toISOString();
+  const updateStmt = db.prepare(
+    `UPDATE processed_notes SET fidelity_tier = ?, fidelity_evaluated_at = ? WHERE raw_note_id = ?`
+  );
+
+  for (const note of notes) {
+    const newTier = computeTier({
+      ageDays: note.age_days,
+      hasEssence: note.essence !== null,
+      threadStatus: note.thread_status,
+      lastAccessDays: note.age_days,
+    });
+
+    if (newTier !== note.fidelity_tier) {
+      updateStmt.run(newTier, now, note.raw_note_id);
+      log.info(
+        { noteId: note.raw_note_id, from: note.fidelity_tier, to: newTier },
+        'Tier changed'
+      );
+      result.processed++;
+      result.details.push({ id: note.raw_note_id, success: true });
+    }
+  }
+
+  log.info(
+    { evaluated: notes.length, changed: result.processed },
+    'Fidelity evaluation complete'
+  );
+  return result;
+}
+
+// CLI entry point
+if (require.main === module) {
+  evaluateFidelity()
+    .then((result) => {
+      console.log('Evaluate-fidelity complete:', result);
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error('Evaluate-fidelity failed:', err);
+      process.exit(1);
+    });
+}

--- a/src/workflows/process-llm-essence.test.ts
+++ b/src/workflows/process-llm-essence.test.ts
@@ -1,0 +1,46 @@
+import assert from 'assert';
+
+async function runTests() {
+  const { buildEssencePrompt } = await import('./process-llm');
+
+  // Test 1: Prompt includes title, content, and existing concepts
+  {
+    const prompt = buildEssencePrompt(
+      'Morning Reflection',
+      'Woke up feeling scattered. Need to find a system for tracking tasks.',
+      '["task management", "morning routine"]',
+      'productivity'
+    );
+    assert.ok(prompt.includes('Morning Reflection'), 'should include title');
+    assert.ok(prompt.includes('scattered'), 'should include content');
+    assert.ok(prompt.includes('task management'), 'should include concepts');
+    assert.ok(prompt.includes('productivity'), 'should include theme');
+    console.log('  ✓ essence prompt includes all context');
+  }
+
+  // Test 2: Prompt works with null concepts and null theme
+  {
+    const prompt = buildEssencePrompt('Quick Note', 'Just a thought.', null, null);
+    assert.ok(prompt.includes('Quick Note'), 'should include title');
+    assert.ok(prompt.includes('Just a thought'), 'should include content');
+    // Should not crash or include "null"
+    assert.ok(!prompt.includes('null'), 'should not include literal null');
+    console.log('  ✓ essence prompt handles null concepts and theme');
+  }
+
+  // Test 3: Prompt handles malformed JSON in concepts
+  {
+    const prompt = buildEssencePrompt('Bad JSON', 'Content here.', 'not valid json', 'test');
+    assert.ok(prompt.includes('Bad JSON'), 'should include title');
+    assert.ok(prompt.includes('Content here'), 'should include content');
+    // Should not crash
+    console.log('  ✓ essence prompt handles malformed JSON concepts');
+  }
+
+  console.log('\nAll process-llm essence tests passed!');
+}
+
+runTests().catch((err) => {
+  console.error('Tests failed:', err);
+  process.exit(1);
+});

--- a/src/workflows/reconsolidate-threads.ts
+++ b/src/workflows/reconsolidate-threads.ts
@@ -1,4 +1,5 @@
 import { createWorkflowLogger, db, generate, ContextBuilder } from '../lib';
+import type { FidelityTier } from '../lib/context-builder';
 import { normalizeThreadName } from '../lib/strings';
 import type { WorkflowResult } from '../types';
 import { writeFileSync, existsSync, mkdirSync, unlinkSync } from 'fs';
@@ -27,7 +28,7 @@ interface NoteRecord {
   essence: string | null;
   primary_theme: string | null;
   concepts: string | null;
-  fidelity_tier: string;
+  fidelity_tier: FidelityTier;
 }
 
 interface ThreadSynthesis {


### PR DESCRIPTION
## Summary

- **Tiered fidelity system** (full → high → summary → skeleton) compresses notes based on age, thread activity, and essence availability, reducing LLM context window usage for older/inactive content
- **Essence distillation** — LLM generates 1-2 sentence core meaning for each note (inline during processing + backfill workflow for existing notes)
- **ContextBuilder** utility class assembles tiered context within a token budget, used by detect-threads and reconsolidate-threads for smarter prompt construction
- **Thread digests** — narrative paragraph summaries compiled from member note essences for threads with 10+ notes
- **Monitoring** — `/health/compression` endpoint reports tier distribution, essence progress, and digest coverage

## What Changed

| Area | Files | Description |
|------|-------|-------------|
| Migration | `020_tiered_context_compression.sql` | Adds `essence`, `fidelity_tier` to processed_notes; `thread_digest` to threads |
| Core lib | `context-builder.ts` | ContextBuilder class with tiered rendering + token budget |
| New workflows | `distill-essences.ts`, `evaluate-fidelity.ts`, `compile-thread-digests.ts` | Backfill essences, assign tiers, compile thread digests |
| Modified workflows | `process-llm.ts`, `detect-threads.ts`, `reconsolidate-threads.ts`, `daily-summary.ts` | Inline essence computation, ContextBuilder integration, essence preference |
| Server | `server.ts` | `/health/compression` monitoring endpoint |
| Scheduling | 3 new launchd plists | distill-essences (5min), evaluate-fidelity (daily 3am), compile-thread-digests (hourly) |
| Tests | 6 test files, 29 tests | ContextBuilder, computeTier, buildEssencePrompt, buildDigestPrompt |

## Test Plan

- [x] 29 unit tests passing across 6 test files
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Integration test: `distill-essences` processed 10 notes via Ollama against dev database
- [x] Integration test: `evaluate-fidelity` correctly found 0 tier changes (guard rule working — no essences yet)
- [ ] Apply migration to production database
- [ ] Install 3 new launchd plists via `install-launchd.sh`
- [ ] Monitor `/health/compression` endpoint after first full cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)